### PR TITLE
Fix HAL output device configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2.9.0",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-fs": "^2.4.2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@types/plotly.js": "^3.0.7",
         "bulma": "^1.0.4",
         "chrome-devtools-mcp": "^0.9.0",
@@ -223,7 +224,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -266,7 +266,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2103,6 +2102,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2192,7 +2200,6 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2320,7 +2327,6 @@
       "version": "8.46.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2632,7 +2638,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.3",
         "fflate": "^0.8.2",
@@ -2820,7 +2825,6 @@
       "integrity": "sha512-i38o7wlipLllNrk2hzdDfAmk6nrqm3lR2MtAgWgtHbwznZAKkB84KpkNFfmUXw5Kg3iP1zKlSjwZpKqenuLc+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -2865,7 +2869,6 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -3090,7 +3093,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4678,7 +4680,6 @@
       "version": "9.38.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4950,7 +4951,6 @@
       "integrity": "sha512-/XxRRR90gNSuNf++w1jOQjhC5LE9Ixf/iAQctVb/miEI3dwzPZTuG27/omoh5REfSLDoPXofM84vAH/ULtz35g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^3.2.4",
         "deep-eql": "^5.0.2",
@@ -6271,7 +6271,6 @@
     "node_modules/jiti": {
       "version": "2.6.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6296,7 +6295,6 @@
       "version": "27.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -6763,7 +6761,6 @@
       "version": "0.18.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "14.1.0",
         "js-yaml": "4.1.0",
@@ -8197,7 +8194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9438,7 +9434,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9575,7 +9570,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9694,7 +9688,6 @@
       "version": "7.1.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9811,7 +9804,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9823,7 +9815,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.3",
         "@vitest/mocker": "4.0.3",
@@ -9996,7 +9987,6 @@
       "integrity": "sha512-cqaXfahTzCFaQLlk++feZaze6tAsW8OSdaVRgmOGJRII1z2A4uh4YGHtusTpqOiZAST7OBPqycOwfh01G/Ktbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2.4.2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@types/plotly.js": "^3.0.7",
     "bulma": "^1.0.4",
     "chrome-devtools-mcp": "^0.9.0",

--- a/src-ui-frontend/modules/audio-capture/capture-config-panel.ts
+++ b/src-ui-frontend/modules/audio-capture/capture-config-panel.ts
@@ -13,6 +13,8 @@ import {
 } from "./capture-tauri";
 import { save, open } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { appDataDir } from "@tauri-apps/api/path";
 
 console.log("[MODULE] capture-config-panel.ts imports complete");
 
@@ -249,6 +251,12 @@ export class CaptureConfigPanel extends HTMLElement {
             </button>
           </div>
           <div class="capture-config-actions-right">
+            <button type="button" id="config_minimize_btn" class="btn btn-outline">
+              Minimize
+            </button>
+            <button type="button" id="config_quit_btn" class="btn btn-outline">
+              Quit
+            </button>
             <button type="button" id="config_next_btn" class="btn btn-primary">
               Next →
             </button>
@@ -327,6 +335,28 @@ export class CaptureConfigPanel extends HTMLElement {
     const configNextBtn = this.querySelector("#config_next_btn");
     configNextBtn?.addEventListener("click", () => {
       this.onNext();
+    });
+
+    // Minimize button
+    const configMinimizeBtn = this.querySelector("#config_minimize_btn");
+    configMinimizeBtn?.addEventListener("click", async () => {
+      try {
+        const window = getCurrentWindow();
+        await window.minimize();
+      } catch (error) {
+        console.error("Failed to minimize window:", error);
+      }
+    });
+
+    // Quit button
+    const configQuitBtn = this.querySelector("#config_quit_btn");
+    configQuitBtn?.addEventListener("click", async () => {
+      try {
+        const window = getCurrentWindow();
+        await window.close();
+      } catch (error) {
+        console.error("Failed to quit application:", error);
+      }
     });
 
     // Initialize with default channel counts
@@ -493,9 +523,13 @@ export class CaptureConfigPanel extends HTMLElement {
 
   private async loadConfig(): Promise<void> {
     try {
-      // Open file dialog
+      // Get the app data directory (~/Library/Application Support/org.spinorama.sotf on macOS)
+      const appDir = await appDataDir();
+
+      // Open file dialog with default path to app support directory
       const filePath = await open({
         title: "Load Capture Configuration",
+        defaultPath: appDir,
         filters: [
           {
             name: "JSON",


### PR DESCRIPTION
- Add Minimize button to minimize the window instead of closing
- Add Quit button to properly close the application
- Update Load Config to default to app support directory (~/Library/Application Support/org.spinorama.sotf/ on macOS)
- Use Tauri window API for window controls
- Output device selector already lists all available HAL devices

Changes:
- Added getCurrentWindow and appDataDir imports from Tauri APIs
- Added minimize and quit button UI elements
- Configured file dialog to open in app data directory by default
- Updated event handlers for new buttons