### PR TITLE
feat: Add VST3/CLAP EQ plugin with egui editor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,10 @@
 # macOS-specific configuration
 MACOSX_DEPLOYMENT_TARGET = "15.0"
 
+# Alias for nih-plug bundler
+[alias]
+xtask = "run --package xtask --"
+
 [build]
 rustflags = ["-Ctarget-cpu=native"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "accelerate-src"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +138,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-activity"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+dependencies = [
+ "android-properties",
+ "bitflags 2.10.0",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +234,12 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "anymap3"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "approx"
@@ -270,7 +319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
 dependencies = [
  "ash",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "raw-window-metal",
 ]
 
@@ -286,7 +335,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "rand 0.9.2",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "serde",
  "serde_repr",
  "url",
@@ -353,7 +402,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -624,6 +673,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_float"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62af46d040ba9df09edc6528dae9d8e49f5f3e82f55b7d2ec31a733c38dbc49d"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +758,19 @@ checksum = "0eb33db5402bc364e5d254144019fff082ce236c4bff531542268fb6907ea919"
 dependencies = [
  "chrono",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "autoeq-iir"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de50b4bb02dbf2b9813433d9da57a7b26eeea6d9c3e87be04119a0b277583eff"
+dependencies = [
+ "base64",
+ "byteorder",
+ "ndarray 0.16.1",
+ "num-complex",
+ "serde",
 ]
 
 [[package]]
@@ -763,6 +848,23 @@ name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+
+[[package]]
+name = "baseview"
+version = "0.1.0"
+source = "git+https://github.com/RustAudio/baseview.git?rev=9a0b42c09d712777b2edb4c5e0cb6baf21e988f0#9a0b42c09d712777b2edb4c5e0cb6baf21e988f0"
+dependencies = [
+ "cocoa 0.24.1",
+ "core-foundation 0.9.4",
+ "keyboard-types",
+ "nix 0.22.3",
+ "objc",
+ "raw-window-handle 0.5.2",
+ "uuid 0.8.2",
+ "winapi",
+ "x11",
+ "x11rb",
+]
 
 [[package]]
 name = "basic-toml"
@@ -943,15 +1045,15 @@ dependencies = [
  "log",
  "mint",
  "naga 25.0.1",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
- "objc2-quartz-core",
- "objc2-ui-kit",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "once_cell",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "slab",
  "wasm-bindgen",
  "web-sys",
@@ -1056,11 +1158,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -1144,6 +1255,20 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9f6e1368bd4621d2c86baa7e37de77a938adf5221e5dd3d6133340101b309e"
@@ -1161,10 +1286,42 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
- "calloop",
+ "calloop 0.14.3",
  "rustix 1.1.3",
  "wayland-backend",
  "wayland-client",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1383,6 +1540,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-sys"
+version = "0.5.0"
+source = "git+https://github.com/micahrj/clap-sys.git?rev=25d7f53fdb6363ad63fbd80049cb7a42a97ac156#25d7f53fdb6363ad63fbd80049cb7a42a97ac156"
+
+[[package]]
 name = "clap_builder"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,12 +1575,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation 0.1.2",
+ "core-foundation 0.9.4",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -1620,6 +1807,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "copypasta"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
+dependencies = [
+ "clipboard-win",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "x11-clipboard",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1844,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -1847,13 +2060,13 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
- "objc2",
+ "objc2 0.6.3",
  "objc2-audio-toolbox",
  "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2087,6 +2300,12 @@ dependencies = [
  "nix 0.30.1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -2425,9 +2644,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -2464,6 +2683,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dtor"
@@ -2517,10 +2742,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecolor"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "egui"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+dependencies = [
+ "ahash",
+ "bitflags 2.10.0",
+ "emath",
+ "epaint",
+ "nohash-hasher",
+ "profiling",
+]
+
+[[package]]
+name = "egui-baseview"
+version = "0.5.0"
+source = "git+https://github.com/BillyDM/egui-baseview.git?rev=ec70c3fe6b2f070dcacbc22924431edbe24bd1c0#ec70c3fe6b2f070dcacbc22924431edbe24bd1c0"
+dependencies = [
+ "baseview",
+ "copypasta",
+ "egui",
+ "egui_glow",
+ "keyboard-types",
+ "log",
+ "open",
+ "raw-window-handle 0.5.2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow 0.16.0",
+ "log",
+ "memoffset 0.9.1",
+ "profiling",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "emath"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "embed-resource"
@@ -2615,6 +2907,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2975,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etagere"
@@ -3326,6 +3647,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,7 +3736,7 @@ dependencies = [
  "blade-util",
  "block",
  "bytemuck",
- "calloop",
+ "calloop 0.14.3",
  "calloop-wayland-source",
  "cbindgen 0.28.0",
  "circular-buffer",
@@ -3448,7 +3780,7 @@ dependencies = [
  "postage",
  "profiling",
  "rand 0.9.2",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "refineable",
  "resvg",
  "schemars 1.2.0",
@@ -3468,7 +3800,7 @@ dependencies = [
  "usvg",
  "util",
  "util_macros",
- "uuid",
+ "uuid 1.19.0",
  "waker-fn",
  "wayland-backend",
  "wayland-client",
@@ -3566,7 +3898,7 @@ dependencies = [
  "gpui-ui-kit-macros",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.19.0",
 ]
 
 [[package]]
@@ -3699,6 +4031,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -4276,7 +4617,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -4416,6 +4757,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7668b7cff6a51fe61cdde64cd27c8a220786f399501b57ebe36f7d8112fd68"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4905,6 +5255,15 @@ checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4965,6 +5324,12 @@ dependencies = [
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "midi-consts"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2dd5c7f8aaf48a76e389068ab25ed80bdbc226b887f9013844c415698c9952"
 
 [[package]]
 name = "midir"
@@ -5132,6 +5497,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
+ "cblas-sys",
+ "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -5140,6 +5507,7 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -5204,6 +5572,7 @@ dependencies = [
  "log",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
+ "raw-window-handle 0.6.2",
  "thiserror 1.0.69",
 ]
 
@@ -5263,6 +5632,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nih_log"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0cdb52ef79af48ae110401c883bdb9c15e0306a99ab6ecf18bc52068b668e54"
+dependencies = [
+ "atty",
+ "log",
+ "once_cell",
+ "termcolor",
+ "time",
+ "windows 0.44.0",
+]
+
+[[package]]
+name = "nih_plug"
+version = "0.0.0"
+source = "git+https://github.com/robbert-vdh/nih-plug.git#28b149ec4d62757d0b448809148a0c3ca6e09a95"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "atomic_float",
+ "atomic_refcell",
+ "backtrace",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clap-sys",
+ "core-foundation 0.9.4",
+ "crossbeam",
+ "libc",
+ "log",
+ "midi-consts",
+ "nih_log",
+ "nih_plug_derive",
+ "objc",
+ "parking_lot",
+ "raw-window-handle 0.5.2",
+ "serde",
+ "serde_json",
+ "vst3-sys",
+ "widestring",
+ "windows 0.44.0",
+]
+
+[[package]]
+name = "nih_plug_derive"
+version = "0.1.0"
+source = "git+https://github.com/robbert-vdh/nih-plug.git#28b149ec4d62757d0b448809148a0c3ca6e09a95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "nih_plug_egui"
+version = "0.0.0"
+source = "git+https://github.com/robbert-vdh/nih-plug.git#28b149ec4d62757d0b448809148a0c3ca6e09a95"
+dependencies = [
+ "baseview",
+ "crossbeam",
+ "egui-baseview",
+ "nih_plug",
+ "parking_lot",
+ "raw-window-handle 0.5.2",
+ "serde",
+]
+
+[[package]]
+name = "nih_plug_xtask"
+version = "0.1.0"
+source = "git+https://github.com/robbert-vdh/nih-plug.git#28b149ec4d62757d0b448809148a0c3ca6e09a95"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "goblin",
+ "reflink",
+ "serde",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,7 +5735,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -5285,7 +5748,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -5296,6 +5759,12 @@ checksum = "c6347753a7143118e8477544749322f5f23c8b63e485e9663dde696bdf425bf0"
 dependencies = [
  "cmake",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noisy_float"
@@ -5531,7 +6000,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -5588,6 +6057,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5598,16 +6083,32 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -5618,11 +6119,11 @@ checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5632,19 +6133,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-avf-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-image-io",
  "objc2-media-toolbox",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -5653,8 +6154,32 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5664,10 +6189,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5677,7 +6202,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5687,10 +6224,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -5701,9 +6238,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.10.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5712,14 +6261,26 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-image-io",
- "objc2-metal",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5729,9 +6290,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
@@ -5744,8 +6305,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5755,12 +6316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
- "objc2-metal",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -5771,14 +6332,27 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -5788,7 +6362,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -5800,8 +6374,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5810,10 +6396,22 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5823,9 +6421,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5835,10 +6446,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
 ]
 
 [[package]]
@@ -5848,10 +6490,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5860,16 +6526,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
 dependencies = [
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.3",
  "objc2-av-foundation",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-media",
  "objc2-core-ml",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-image-io",
 ]
 
@@ -5947,7 +6613,7 @@ dependencies = [
  "toml 0.8.23",
  "ureq 2.12.1",
  "url",
- "uuid",
+ "uuid 1.19.0",
  "walkdir",
 ]
 
@@ -6092,6 +6758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
+dependencies = [
+ "libredox",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,6 +6808,15 @@ dependencies = [
  "sha2",
  "tar",
  "ureq 3.1.4",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -6405,6 +7089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotly"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6500,7 +7190,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -6959,6 +7649,12 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
@@ -6972,7 +7668,7 @@ dependencies = [
  "cocoa 0.25.0",
  "core-graphics 0.23.2",
  "objc",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
 ]
 
 [[package]]
@@ -7043,6 +7739,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -7107,6 +7812,15 @@ version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed.git#554382a87e2f51496c2f907554e309d0e589b3d2"
 dependencies = [
  "derive_refineable",
+]
+
+[[package]]
+name = "reflink"
+version = "0.1.3"
+source = "git+https://github.com/nicokoch/reflink.git?rev=e8d93b465f5d9ad340cd052b64bbc77b8ee107e2#e8d93b465f5d9ad340cd052b64bbc77b8ee107e2"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -7205,16 +7919,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
  "ashpd 0.11.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "pollster 0.4.0",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7586,6 +8300,26 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "once_cell",
+]
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -7970,6 +8704,9 @@ name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -8088,7 +8825,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "unicode-normalization",
- "uuid",
+ "uuid 1.19.0",
  "walkdir",
 ]
 
@@ -8178,6 +8915,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sotf-audio-plugins-vst3"
+version = "0.5.1"
+dependencies = [
+ "autoeq-iir",
+ "log",
+ "nih_plug",
+ "nih_plug_egui",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sotf-audio-plugins",
+]
+
+[[package]]
 name = "sotf-gpui"
 version = "0.5.8"
 dependencies = [
@@ -8248,20 +8999,20 @@ dependencies = [
 name = "sotf-head-tracker"
 version = "0.5.8"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "crossbeam",
  "dispatch",
  "env_logger 0.11.8",
  "image",
  "log",
  "nokhwa",
- "objc2",
+ "objc2 0.6.3",
  "objc2-av-foundation",
  "objc2-core-foundation",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-media",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-vision",
  "ort",
  "parking_lot",
@@ -9165,6 +9916,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -9187,7 +9950,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9210,6 +9973,19 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -9219,7 +9995,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9231,7 +10007,7 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9240,7 +10016,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9419,7 +10195,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "winapi",
 ]
@@ -9708,6 +10484,15 @@ dependencies = [
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
@@ -9804,6 +10589,43 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vst3-com"
+version = "0.1.0"
+source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+dependencies = [
+ "vst3-com-macros",
+]
+
+[[package]]
+name = "vst3-com-macros"
+version = "0.2.0"
+source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "vst3-com-macros-support",
+]
+
+[[package]]
+name = "vst3-com-macros-support"
+version = "0.2.0"
+source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "vst3-sys"
+version = "0.1.0"
+source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+dependencies = [
+ "vst3-com",
+]
 
 [[package]]
 name = "vswhom"
@@ -10041,6 +10863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10093,7 +10925,7 @@ dependencies = [
  "mac_address",
  "sha2",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 1.19.0",
 ]
 
 [[package]]
@@ -10159,7 +10991,7 @@ dependencies = [
  "naga 23.1.0",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "smallvec 1.15.1",
  "static_assertions",
  "wasm-bindgen",
@@ -10187,7 +11019,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
  "thiserror 1.0.69",
@@ -10228,7 +11060,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
@@ -10287,6 +11119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10316,6 +11154,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows"
@@ -11010,6 +11857,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+dependencies = [
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle 0.6.2",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11087,6 +11987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11095,6 +12006,8 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
+ "libloading",
+ "once_cell",
  "rustix 1.1.3",
  "x11rb-protocol",
  "xcursor",
@@ -11172,6 +12085,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.10.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11188,6 +12114,13 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "nih_plug_xtask",
+]
 
 [[package]]
 name = "y4m"
@@ -11261,9 +12194,9 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.19.0",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.14",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -11292,7 +12225,7 @@ checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow",
+ "winnow 0.7.14",
  "zvariant",
 ]
 
@@ -11536,7 +12469,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow",
+ "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -11564,5 +12497,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.112",
- "winnow",
+ "winnow 0.7.14",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
 
 [[package]]
+name = "accesskit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "serde",
+ "thiserror 1.0.69",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite 2.6.1",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "static_assertions",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle 0.6.2",
+ "winit",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +155,7 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -320,7 +411,7 @@ checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
 dependencies = [
  "ash",
  "raw-window-handle 0.6.2",
- "raw-window-metal",
+ "raw-window-metal 0.4.0",
 ]
 
 [[package]]
@@ -685,6 +776,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
+name = "atspi"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
+dependencies = [
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite 2.6.1",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +834,18 @@ dependencies = [
  "hermit-abi 0.1.19",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "auto_enums"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c170965892137a3a9aeb000b4524aa3cc022a310e709d848b6e1cdce4ab4781"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -856,7 +1009,7 @@ source = "git+https://github.com/RustAudio/baseview.git?rev=9a0b42c09d712777b2ed
 dependencies = [
  "cocoa 0.24.1",
  "core-foundation 0.9.4",
- "keyboard-types",
+ "keyboard-types 0.6.2",
  "nix 0.22.3",
  "objc",
  "raw-window-handle 0.5.2",
@@ -882,6 +1035,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "serde",
+ "unty",
 ]
 
 [[package]]
@@ -959,6 +1122,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1014,6 +1179,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -1188,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "cfg_aliases 0.2.1",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1391,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -1278,6 +1461,18 @@ dependencies = [
  "rustix 1.1.3",
  "slab",
  "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -1542,6 +1737,12 @@ dependencies = [
 [[package]]
 name = "clap-sys"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76abbdb2907f6fd97fb6bc0b7be96b77d328f2dd9669d1075cc03369ed22154"
+
+[[package]]
+name = "clap-sys"
+version = "0.5.0"
 source = "git+https://github.com/micahrj/clap-sys.git?rev=25d7f53fdb6363ad63fbd80049cb7a42a97ac156#25d7f53fdb6363ad63fbd80049cb7a42a97ac156"
 
 [[package]]
@@ -1582,6 +1783,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "clru"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
 name = "cmake"
@@ -1669,6 +1876,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "codemap"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
+
+[[package]]
+name = "codemap-diagnostic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc20770be05b566a963bf91505e60412c4a2d016d1ef95c5512823bb085a8122"
+dependencies = [
+ "codemap",
+ "termcolor",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1932,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "com-scrape-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce183b975b8fc736a20919c4002717255fbd867df575c792aeefa9a56a73ad0"
 
 [[package]]
 name = "combine"
@@ -1769,6 +1998,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-field-offset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255"
+dependencies = [
+ "const-field-offset-macro",
+ "field-offset",
+]
+
+[[package]]
+name = "const-field-offset-macro"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2033,7 +2283,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "rustybuzz 0.14.1",
  "self_cell",
- "smol_str",
+ "smol_str 0.2.2",
  "swash",
  "sys-locale",
  "ttf-parser 0.21.1",
@@ -2042,6 +2292,12 @@ dependencies = [
  "unicode-script",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpal"
@@ -2126,6 +2382,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -2283,6 +2545,12 @@ dependencies = [
  "ctor-proc-macro",
  "dtor",
 ]
+
+[[package]]
+name = "ctor-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -2537,12 +2805,24 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.112",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed.git#554382a87e2f51496c2f907554e309d0e589b3d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2774,7 +3054,7 @@ dependencies = [
  "copypasta",
  "egui",
  "egui_glow",
- "keyboard-types",
+ "keyboard-types 0.6.2",
  "log",
  "open",
  "raw-window-handle 0.5.2",
@@ -3127,6 +3407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset 0.9.1",
+ "rustc_version",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,7 +3568,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
 dependencies = [
  "hashbrown 0.15.5",
+ "rayon",
  "ttf-parser 0.21.1",
+]
+
+[[package]]
+name = "fontique"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3336bc0b87fe42305047263fa60d2eabd650d29cbe62fdeb2a66c7a0a595f9"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.15.5",
+ "icu_locale_core",
+ "linebender_resource_handle",
+ "memmap2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "read-fonts",
+ "roxmltree",
+ "smallvec 1.15.1",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -3538,6 +3852,16 @@ dependencies = [
 
 [[package]]
 name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
@@ -3635,6 +3959,50 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg_aliases 0.2.1",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle 0.6.2",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
 ]
 
 [[package]]
@@ -3737,7 +4105,7 @@ dependencies = [
  "block",
  "bytemuck",
  "calloop 0.14.3",
- "calloop-wayland-source",
+ "calloop-wayland-source 0.4.1",
  "cbindgen 0.28.0",
  "circular-buffer",
  "cocoa 0.26.0",
@@ -3959,6 +4327,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec 1.15.1",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,6 +4363,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "rayon",
 ]
 
 [[package]]
@@ -4254,6 +4636,184 @@ dependencies = [
 ]
 
 [[package]]
+name = "i-slint-backend-selector"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e138660c634d6bbdf98bb2d0cfa487cda28e032e133a2a2c974f1cc494198765"
+dependencies = [
+ "cfg-if",
+ "i-slint-backend-winit",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+]
+
+[[package]]
+name = "i-slint-backend-winit"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bf9167fb1165942ef1f034e039645b60b07b23c0c76069cb83595f979243a4"
+dependencies = [
+ "accesskit",
+ "accesskit_winit",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "copypasta",
+ "derive_more 2.1.1",
+ "futures",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "i-slint-renderer-skia",
+ "lyon_path",
+ "muda",
+ "objc2-app-kit 0.3.2",
+ "pin-weak",
+ "raw-window-handle 0.6.2",
+ "scoped-tls-hkt",
+ "scopeguard",
+ "strum 0.27.2",
+ "vtable",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.62.2",
+ "winit",
+ "zbus",
+]
+
+[[package]]
+name = "i-slint-common"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3566194c13f8dcf6e9f41a2090c96f08cf3f59b60c91380a86c1ed72f6e7d19"
+dependencies = [
+ "fontique",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "i-slint-compiler"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a301031f6c1da6acdd483641cc44109b34990e5edd67478eb0cbca359ab7ae3f"
+dependencies = [
+ "by_address",
+ "codemap",
+ "codemap-diagnostic",
+ "derive_more 2.1.1",
+ "fontdue",
+ "i-slint-common",
+ "image",
+ "itertools 0.14.0",
+ "linked_hash_set",
+ "lyon_extra",
+ "lyon_path",
+ "num_enum",
+ "polib",
+ "proc-macro2",
+ "quote",
+ "rayon",
+ "resvg",
+ "rowan",
+ "smol_str 0.3.4",
+ "strum 0.27.2",
+ "typed-index-collections",
+ "url",
+]
+
+[[package]]
+name = "i-slint-core"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc140f1218cfc4451b9e8753306c42afbcaf0386cc888e53664c1a5f5330ae19"
+dependencies = [
+ "auto_enums",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "chrono",
+ "clru",
+ "const-field-offset",
+ "derive_more 2.1.1",
+ "euclid",
+ "i-slint-common",
+ "i-slint-core-macros",
+ "image",
+ "integer-sqrt",
+ "lyon_algorithms",
+ "lyon_extra",
+ "lyon_geom",
+ "lyon_path",
+ "num-traits",
+ "once_cell",
+ "parley",
+ "pin-project",
+ "pin-weak",
+ "portable-atomic",
+ "raw-window-handle 0.6.2",
+ "resvg",
+ "rgb",
+ "scoped-tls-hkt",
+ "scopeguard",
+ "slab",
+ "strum 0.27.2",
+ "sys-locale",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
+ "vtable",
+ "wasm-bindgen",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "i-slint-core-macros"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4c6a3975ccaa66415f5524292750e631879e69178aa97e3928d2396b790d00d"
+dependencies = [
+ "quote",
+ "serde_json",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "i-slint-renderer-skia"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ed0d42d66c457b7937d7f5ee07d2fbef3691c896a26212a69b30288844ddd"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "const-field-offset",
+ "derive_more 2.1.1",
+ "glow 0.16.0",
+ "glutin",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "lyon_path",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "pin-weak",
+ "raw-window-handle 0.6.2",
+ "raw-window-metal 1.1.0",
+ "read-fonts",
+ "scoped-tls-hkt",
+ "skia-safe",
+ "softbuffer",
+ "unicode-segmentation",
+ "vtable",
+ "windows 0.62.2",
+ "write-fonts",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,6 +4858,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -4412,7 +4973,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.14.1",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -4530,6 +5091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4769,6 +5339,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.10.0",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,6 +5391,17 @@ name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -4987,6 +5579,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linereader"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d921fea6860357575519aca014c6e22470585accdd543b370c404a8a72d0dd1d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,6 +5687,16 @@ checksum = "f4c0829e28c4f336396f250d850c3987e16ce6db057ffe047ce0dd54aab6b647"
 dependencies = [
  "lyon_path",
  "num-traits",
+]
+
+[[package]]
+name = "lyon_extra"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca94c7bf1e2557c2798989c43416822c12fc5dcc5e17cc3307ef0e71894a955"
+dependencies = [
+ "lyon_path",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5420,6 +6052,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "muda"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "keyboard-types 0.7.0",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png 0.17.16",
+ "thiserror 2.0.17",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "naga"
 version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5657,7 +6308,7 @@ dependencies = [
  "backtrace",
  "bitflags 1.3.2",
  "cfg-if",
- "clap-sys",
+ "clap-sys 0.5.0 (git+https://github.com/micahrj/clap-sys.git?rev=25d7f53fdb6363ad63fbd80049cb7a42a97ac156)",
  "core-foundation 0.9.4",
  "crossbeam",
  "libc",
@@ -6091,7 +6742,7 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
+ "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
@@ -6105,8 +6756,15 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
 ]
@@ -6172,6 +6830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-contacts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6218,6 +6887,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6237,10 +6917,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -6307,6 +6990,18 @@ checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
 dependencies = [
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -6446,8 +7141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
 ]
@@ -6471,8 +7170,8 @@ dependencies = [
  "bitflags 2.10.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -6622,6 +7321,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6851,6 +7554,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "parley"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26746861bb76dbc9bcd5ed1b0b55d2fedf291100961251702a031ab2abd2ce52"
+dependencies = [
+ "fontique",
+ "harfrust",
+ "hashbrown 0.15.5",
+ "linebender_resource_handle",
+ "skrifa",
+ "swash",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7072,6 +7789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pin-weak"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b330c9d1b92dfe68442ca20b009c717d5f0b1e3cf4965e62f704c3c6e95a1305"
+
+[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7093,6 +7816,44 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plinth-core"
+version = "0.1.0"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+]
+
+[[package]]
+name = "plinth-derive"
+version = "0.1.0"
+dependencies = [
+ "plinth-plugin",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "plinth-plugin"
+version = "0.1.0"
+dependencies = [
+ "atomic_refcell",
+ "bindgen 0.72.1",
+ "clap-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "num-derive",
+ "num-traits",
+ "plinth-core",
+ "portable-atomic",
+ "raw-window-handle 0.6.2",
+ "rtrb",
+ "thiserror 2.0.17",
+ "vst3",
+ "widestring",
+ "xxhash-rust",
+]
 
 [[package]]
 name = "plotly"
@@ -7157,6 +7918,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin-canvas"
+version = "0.0.0"
+dependencies = [
+ "bitflags 2.10.0",
+ "cursor-icon",
+ "keyboard-types 0.7.0",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "raw-window-handle 0.6.2",
+ "sys-locale",
+ "uuid 1.19.0",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "x11rb",
+ "xkbcommon",
+]
+
+[[package]]
+name = "plugin-canvas-slint"
+version = "0.1.0"
+dependencies = [
+ "cursor-icon",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-renderer-skia",
+ "keyboard-types 0.7.0",
+ "log",
+ "plugin-canvas",
+ "portable-atomic",
+ "raw-window-handle 0.6.2",
+ "slint",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7180,6 +7980,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polib"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b393b155cf9be86249cba1b56cc81be0e6212c66d94ac0d76d37a1761f3bb1b"
+dependencies = [
+ "linereader",
 ]
 
 [[package]]
@@ -7213,6 +8022,10 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+dependencies = [
+ "critical-section",
+ "serde",
+]
 
 [[package]]
 name = "portable-atomic-util"
@@ -7389,6 +8202,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -7672,6 +8495,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7716,6 +8551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
+ "core_maths",
  "font-types",
 ]
 
@@ -7904,12 +8740,15 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
+ "gif 0.13.3",
+ "image-webp",
  "log",
  "pico-args",
  "rgb",
  "svgtypes",
  "tiny-skia",
  "usvg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -7964,6 +8803,18 @@ name = "robust"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
 
 [[package]]
 name = "roxmltree"
@@ -8272,6 +9123,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scoped-tls-hkt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9603871ffe5df3ac39cb624790c296dbd47a400d202f56bf3e414045099524d"
 
 [[package]]
 name = "scopeguard"
@@ -8646,6 +9503,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "skia-bindings"
+version = "0.89.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f06b9b01a0d1189fa756bb9aec034554d52ad53f2f33d80a96e7a4ecfbd3d989"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "flate2",
+ "heck 0.5.0",
+ "pkg-config",
+ "regex",
+ "serde_json",
+ "tar",
+ "toml 0.9.10+spec-1.1.0",
+]
+
+[[package]]
+name = "skia-safe"
+version = "0.89.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced1fcc0fa7510f9339988f31d831e14f64f9aa771e5f93f4935431e6fe69d4c"
+dependencies = [
+ "bitflags 2.10.0",
+ "skia-bindings",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "skrifa"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8660,6 +9545,48 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "slint"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c35c4bdca2c42c69b21ceb416aa4ba76c3f54df30e9ce85dcad0742229422a6"
+dependencies = [
+ "const-field-offset",
+ "i-slint-backend-selector",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "num-traits",
+ "once_cell",
+ "pin-weak",
+ "slint-macros",
+ "unicode-segmentation",
+ "vtable",
+]
+
+[[package]]
+name = "slint-build"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f9e30dfc58198894a4a4fe38d126a24ed4121d11cd8564643f3b7915752adc"
+dependencies = [
+ "derive_more 2.1.1",
+ "i-slint-compiler",
+ "spin_on",
+ "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
+name = "slint-macros"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b4b4bada19852716991153ddd93bf133548ac74383a05db8df399b9003bbfe"
+dependencies = [
+ "i-slint-compiler",
+ "proc-macro2",
+ "quote",
+ "spin_on",
+]
 
 [[package]]
 name = "slotmap"
@@ -8681,6 +9608,31 @@ name = "smallvec"
 version = "2.0.0-alpha.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.10.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
 
 [[package]]
 name = "smol"
@@ -8709,6 +9661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8727,6 +9689,33 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+dependencies = [
+ "as-raw-xcb-connection",
+ "bytemuck",
+ "fastrand 2.3.0",
+ "js-sys",
+ "ndk",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "raw-window-handle 0.6.2",
+ "redox_syscall 0.5.18",
+ "rustix 1.1.3",
+ "tiny-xlib",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.61.2",
+ "x11rb",
 ]
 
 [[package]]
@@ -8853,7 +9842,7 @@ version = "0.5.8"
 dependencies = [
  "anyhow",
  "autoeq-env",
- "bincode",
+ "bincode 1.3.3",
  "chrono",
  "clap",
  "cpal",
@@ -8912,6 +9901,23 @@ dependencies = [
  "serde_json",
  "sotf-audio-engine",
  "sotf-audio-plugins",
+]
+
+[[package]]
+name = "sotf-audio-plugins-slint"
+version = "0.5.8"
+dependencies = [
+ "autoeq-iir",
+ "log",
+ "plinth-derive",
+ "plinth-plugin",
+ "plugin-canvas",
+ "plugin-canvas-slint",
+ "raw-window-handle 0.6.2",
+ "serde",
+ "serde_json",
+ "slint",
+ "slint-build",
 ]
 
 [[package]]
@@ -9071,6 +10077,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin_on"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]
@@ -9300,7 +10315,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher",
 ]
 
@@ -9688,6 +10703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9819,12 +10840,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-xlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor-lite",
+ "libloading",
+ "pkg-config",
+ "tracing",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -10007,6 +11042,7 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.14",
 ]
 
@@ -10172,6 +11208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-index-collections"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5318ee4ce62a4e948a33915574021a7a953d83e84fba6e25c72ffcfd7dad35ff"
+dependencies = [
+ "bincode 2.0.1",
+ "serde",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10323,6 +11369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ureq"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10399,7 +11451,7 @@ dependencies = [
  "flate2",
  "fontdb 0.23.0",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -10500,6 +11552,7 @@ dependencies = [
  "atomic 0.6.1",
  "getrandom 0.3.4",
  "js-sys",
+ "rand 0.9.2",
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
@@ -10591,6 +11644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vst3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31e3fe7a6f028ded8c5a9984cf283319e6dc63572c9b71da1d4ee9d71d3b6bf"
+dependencies = [
+ "com-scrape-types",
+]
+
+[[package]]
 name = "vst3-com"
 version = "0.1.0"
 source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix%2Fdrop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
@@ -10645,6 +11707,29 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vtable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753be81c38dff787d177b5939af1fa16f72f0d0d21a6b7d74ae56e29cd26f2a6"
+dependencies = [
+ "const-field-offset",
+ "portable-atomic",
+ "stable_deref_trait",
+ "vtable-macro",
+]
+
+[[package]]
+name = "vtable-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcf6171aa2b0f85718ca5888ca32f6edf61d1849f8e4b3786ad890e5b68f68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -10778,6 +11863,17 @@ dependencies = [
  "rustix 1.1.3",
  "wayland-backend",
  "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.10.0",
+ "cursor-icon",
+ "wayland-backend",
 ]
 
 [[package]]
@@ -11862,6 +12958,7 @@ version = "0.30.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
 dependencies = [
+ "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.10.0",
@@ -11876,6 +12973,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
+ "memmap2",
  "ndk",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -11887,11 +12985,16 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
- "smol_str",
+ "smithay-client-toolkit",
+ "smol_str 0.2.2",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",
@@ -11959,6 +13062,19 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "write-fonts"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+dependencies = [
+ "font-types",
+ "indexmap 2.12.1",
+ "kurbo 0.12.0",
+ "log",
+ "read-fonts",
+]
 
 [[package]]
 name = "writeable"
@@ -12123,6 +13239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12203,6 +13325,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
 name = "zbus_macros"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12226,6 +13372,19 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow 0.7.14",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
+dependencies = [
+ "quick-xml 0.36.2",
+ "serde",
+ "static_assertions",
+ "zbus_names",
  "zvariant",
 ]
 
@@ -12371,6 +13530,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ members = [
     "sotf-audio-midi",
     "sotf-audio-plugins",
     "sotf-audio-plugins/src-ffi",
-    "sotf-audio-plugins/src-vst3",  # VST3/CLAP plugin wrapper
+    "sotf-audio-plugins/src-vst3",  # VST3/CLAP plugin wrapper (egui)
+    "sotf-audio-plugins/src-slint", # VST3/CLAP plugin wrapper (Slint)
     "sotf-hal",         # macOS only
     "sotf-head-tracker", # macOS only (for now)
     "xtask",            # nih-plug bundler for VST3/CLAP
@@ -241,3 +242,4 @@ panic = "unwind"
 lto = true
 codegen-units = 1
 panic = "unwind"  # Changed from "abort" to allow tests to run
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ members = [
     "sotf-audio-midi",
     "sotf-audio-plugins",
     "sotf-audio-plugins/src-ffi",
+    "sotf-audio-plugins/src-vst3",  # VST3/CLAP plugin wrapper
     "sotf-hal",         # macOS only
     "sotf-head-tracker", # macOS only (for now)
+    "xtask",            # nih-plug bundler for VST3/CLAP
 ]
 default-members = [
     "gpui-d3rs",
@@ -105,6 +107,7 @@ special = "0.11"  # Bessel, Hankel, Legendre functions
 spec_math = "0.1.6"
 
 math-iir-fir = { version = "0.2" }
+autoeq-iir = { version = "0.2" }
 math-differential-evolution = { version = "0.2" }
 autoeq-env = { version = "0.2" }
 autoeq-cea2034 = { version = "0.2" }
@@ -157,6 +160,11 @@ crossterm = "0.28"
 # GPUI framework, using HEAD (macros with _)
 gpui = { version="*", git = "https://github.com/zed-industries/zed.git" }
 gpui_macros = { version="*", git = "https://github.com/zed-industries/zed.git" }
+
+# nih-plug for VST3/CLAP plugin development
+nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+nih_plug_egui = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+raw-window-handle = "0.6"
 
 # System and low-level
 objc = "0.2"

--- a/Justfile
+++ b/Justfile
@@ -216,6 +216,101 @@ build-au: build-au-rust build-au-swift
 	echo "✅ Complete Audio Unit build finished"
 
 # ----------------------------------------------------------------------
+# VST3/CLAP PLUGINS (Cross-platform)
+# ----------------------------------------------------------------------
+
+# Build VST3/CLAP plugins for current platform
+build-vst3:
+	cargo xtask bundle sotf-audio-plugins-vst3 --release
+	@echo "✅ VST3/CLAP plugins built successfully"
+	@echo "   Output: target/bundled/"
+
+# Build VST3/CLAP plugins (debug mode)
+build-vst3-debug:
+	cargo xtask bundle sotf-audio-plugins-vst3
+	@echo "✅ VST3/CLAP plugins built (debug)"
+	@echo "   Output: target/bundled/"
+
+# Build for Linux (from Linux host)
+build-vst3-linux:
+	cargo xtask bundle sotf-audio-plugins-vst3 --release
+	@echo "✅ Linux VST3/CLAP plugins built"
+	@echo "   Output: target/bundled/sotf-audio-plugins-vst3.clap"
+	@echo "           target/bundled/sotf-audio-plugins-vst3.vst3"
+
+# Build for macOS (from macOS host)
+build-vst3-macos:
+	cargo xtask bundle sotf-audio-plugins-vst3 --release
+	@echo "✅ macOS VST3 plugin built"
+	@echo "   Output: target/bundled/sotf-audio-plugins-vst3.vst3"
+
+# Build universal macOS binary (Intel + Apple Silicon)
+build-vst3-macos-universal:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	echo "Building macOS universal VST3 plugin..."
+	# Build for both architectures
+	cargo xtask bundle sotf-audio-plugins-vst3 --release --target aarch64-apple-darwin
+	cargo xtask bundle sotf-audio-plugins-vst3 --release --target x86_64-apple-darwin
+	echo "✅ macOS universal VST3 plugins built"
+	echo "   Output: target/bundled/"
+
+# Build for Windows (cross-compile from Linux/macOS)
+build-vst3-windows:
+	cargo xtask bundle sotf-audio-plugins-vst3 --release --target x86_64-pc-windows-msvc
+	@echo "✅ Windows VST3 plugin built"
+	@echo "   Output: target/bundled/sotf-audio-plugins-vst3.vst3"
+
+# Install VST3/CLAP plugins to standard locations
+install-vst3:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	BUNDLED_DIR="target/bundled"
+	if [ "$(uname)" = "Linux" ]; then
+		# Linux plugin locations
+		VST3_DIR="$HOME/.vst3"
+		CLAP_DIR="$HOME/.clap"
+		mkdir -p "$VST3_DIR" "$CLAP_DIR"
+		if [ -d "$BUNDLED_DIR/sotf-audio-plugins-vst3.vst3" ]; then
+			cp -r "$BUNDLED_DIR/sotf-audio-plugins-vst3.vst3" "$VST3_DIR/"
+			echo "✓ Installed VST3 to $VST3_DIR/"
+		fi
+		if [ -f "$BUNDLED_DIR/sotf-audio-plugins-vst3.clap" ]; then
+			cp "$BUNDLED_DIR/sotf-audio-plugins-vst3.clap" "$CLAP_DIR/"
+			echo "✓ Installed CLAP to $CLAP_DIR/"
+		fi
+	elif [ "$(uname)" = "Darwin" ]; then
+		# macOS plugin locations
+		VST3_DIR="$HOME/Library/Audio/Plug-Ins/VST3"
+		mkdir -p "$VST3_DIR"
+		if [ -d "$BUNDLED_DIR/sotf-audio-plugins-vst3.vst3" ]; then
+			cp -r "$BUNDLED_DIR/sotf-audio-plugins-vst3.vst3" "$VST3_DIR/"
+			echo "✓ Installed VST3 to $VST3_DIR/"
+		fi
+	else
+		echo "❌ Unsupported platform for install"
+		exit 1
+	fi
+	echo "✅ VST3/CLAP plugins installed"
+
+# Validate VST3 plugin with pluginval (if installed)
+validate-vst3:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	if command -v pluginval &> /dev/null; then
+		if [ -d "target/bundled/sotf-audio-plugins-vst3.vst3" ]; then
+			echo "Validating VST3 plugin..."
+			pluginval --validate target/bundled/sotf-audio-plugins-vst3.vst3
+		fi
+		if [ -f "target/bundled/sotf-audio-plugins-vst3.clap" ]; then
+			echo "Validating CLAP plugin..."
+			pluginval --validate target/bundled/sotf-audio-plugins-vst3.clap
+		fi
+	else
+		echo "⚠️  pluginval not found. Install from https://github.com/Tracktion/pluginval"
+	fi
+
+# ----------------------------------------------------------------------
 # BENCH
 # ----------------------------------------------------------------------
 
@@ -456,7 +551,13 @@ install-ubuntu-common:
 			 libnetcdf-dev \
 			 libopencv-dev \
 			 libclang-dev \
-			 webkit2gtk-driver
+			 webkit2gtk-driver \
+			 libx11-xcb-dev \
+			 libxcb-icccm4-dev \
+			 libxcb-render0-dev \
+			 libxcb-shape0-dev \
+			 libxcb-xfixes0-dev \
+			 libxkbcommon-dev
 
 install-ubuntu-x86-driver :
 		sudo apt install -y \

--- a/builds/docker-windows-build.md
+++ b/builds/docker-windows-build.md
@@ -1,0 +1,147 @@
+# Building SotF GPUI for Windows using Docker
+
+This guide explains how to build the Windows version of SotF GPUI using Docker on Linux.
+
+## Prerequisites
+
+- Docker installed
+- KVM enabled (for hardware acceleration)
+- At least 8GB RAM available for the VM
+- ~40GB disk space for Windows + build tools
+
+## Quick Start
+
+### 1. Start Windows in Docker
+
+```bash
+# Create persistent storage for Windows and build cache
+mkdir -p ~/docker-windows
+
+# Run Windows 11 with the project mounted
+docker run -it --rm --name windows -e "VERSION=11" \
+  -p 8006:8006 \
+  --device=/dev/kvm \
+  --device=/dev/net/tun \
+  --cap-add NET_ADMIN \
+  -v "$HOME/docker-windows:/storage" \
+  -e RAM_SIZE=64G \
+  -e CPU_CORES=24 \
+  --stop-timeout 120 \
+  docker.io/dockurr/windows
+```
+
+### 2. Access Windows
+
+**Option A - Web Browser (noVNC):**
+Open http://localhost:8006 in your browser
+
+**Option B - RDP Client:**
+```bash
+# Install an RDP client if needed
+sudo apt install remmina
+
+# Connect to localhost:3389
+remmina -c rdp://localhost:3389
+```
+
+### 3. First-Time Setup (one-time)
+
+Open PowerShell as Administrator and run:
+
+```powershell
+# Install Chocolatey (package manager)
+Set-ExecutionPolicy Bypass -Scope Process -Force
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install build tools
+choco install -y visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+choco install -y rust-ms
+choco install -y llvm
+choco install -y git
+
+# Install vcpkg
+cd C:\
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg integrate install
+
+# Install required libraries
+.\vcpkg install openblas:x64-windows
+.\vcpkg install nlopt:x64-windows
+
+# Set environment variables (permanent)
+[Environment]::SetEnvironmentVariable("VCPKG_ROOT", "C:\vcpkg", "Machine")
+[Environment]::SetEnvironmentVariable("LIBCLANG_PATH", "C:\Program Files\LLVM\bin", "Machine")
+
+# Restart PowerShell to pick up new environment variables
+```
+
+### 4. Build SotF GPUI
+
+After setup, build the project:
+
+```powershell
+# Navigate to mounted project
+cd Z:\sotf
+
+# Run the build script
+.\sotf-audio-player\windows\build-windows.ps1 -InstallDeps
+
+# Or build just GPUI
+.\sotf-audio-player\windows\build-windows.ps1 -GpuiOnly
+```
+
+The built binaries will be in `Z:\sotf\dist\`.
+
+## Tips
+
+### Persist Windows Installation
+
+The first run downloads and installs Windows (~5-10GB). The installation is saved to `~/docker-windows/` so subsequent runs are faster.
+
+### Increase Performance
+
+```bash
+# Use more RAM and CPU cores if available
+docker run ... -e RAM_SIZE=16G -e CPU_CORES=8 ...
+```
+
+### Headless Builds (after initial setup)
+
+Once Windows is set up with all tools, you can run builds via RDP/VNC without a GUI by using PowerShell remoting.
+
+### Check KVM Support
+
+```bash
+# Verify KVM is available
+ls -la /dev/kvm
+
+# If not available, load the module
+sudo modprobe kvm
+sudo modprobe kvm_intel  # or kvm_amd for AMD CPUs
+```
+
+## Troubleshooting
+
+### "KVM not available"
+
+Ensure virtualization is enabled in BIOS and KVM modules are loaded:
+```bash
+sudo apt install qemu-kvm
+sudo usermod -aG kvm $USER
+# Log out and back in
+```
+
+### Slow Performance
+
+- Increase RAM_SIZE and CPU_CORES
+- Ensure KVM is working (not falling back to TCG emulation)
+- Use SSD storage for ~/docker-windows
+
+### Build Errors
+
+- Ensure all environment variables are set correctly
+- Try running `vcpkg integrate install` again
+- Check that LLVM/libclang is installed properly

--- a/sotf-audio-plugins/src-slint/Cargo.toml
+++ b/sotf-audio-plugins/src-slint/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "sotf-audio-plugins-slint"
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+description = "VST3/CLAP EQ plugin with Slint UI using plinth-plugin"
+license = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Plugin framework from local fork of plugin-things (patched for vst3 0.3)
+plinth-plugin = { path = "../../../plugin-things-fork/plinth-plugin" }
+plinth-derive = { path = "../../../plugin-things-fork/plinth-derive" }
+plugin-canvas = { path = "../../../plugin-things-fork/plugin-canvas" }
+plugin-canvas-slint = { path = "../../../plugin-things-fork/plugin-canvas-slint" }
+
+# Slint UI
+slint = { version = "1.13", default-features = false, features = ["std", "compat-1-2"] }
+
+# SOTF audio processing
+autoeq-iir = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Utilities
+log = { workspace = true }
+raw-window-handle = { workspace = true }
+
+[build-dependencies]
+slint-build = "1.13"

--- a/sotf-audio-plugins/src-slint/build.rs
+++ b/sotf-audio-plugins/src-slint/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    slint_build::compile("ui/main.slint").expect("Slint build failed");
+}

--- a/sotf-audio-plugins/src-slint/src/editor.rs
+++ b/sotf-audio-plugins/src-slint/src/editor.rs
@@ -1,0 +1,59 @@
+//! EQ Plugin Editor
+//!
+//! Manages the plugin editor window lifecycle.
+
+use crate::parameters::EqParameters;
+use crate::view::EqPluginView;
+use plinth_plugin::{Editor, Host};
+use plugin_canvas::window::WindowAttributes;
+use plugin_canvas::LogicalSize;
+use plugin_canvas_slint::editor::{EditorHandle, SlintEditor};
+use raw_window_handle::RawWindowHandle;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// EQ Plugin Editor
+pub struct EqPluginEditor {
+    host: Rc<dyn Host>,
+    editor_handle: Option<Rc<EditorHandle>>,
+    parameters: Arc<EqParameters>,
+}
+
+impl EqPluginEditor {
+    pub fn new(host: Rc<dyn Host>, parameters: Arc<EqParameters>) -> Self {
+        Self {
+            host,
+            editor_handle: None,
+            parameters,
+        }
+    }
+}
+
+impl Editor for EqPluginEditor {
+    const DEFAULT_SIZE: (f64, f64) = (800.0, 500.0);
+
+    fn open(&mut self, parent: RawWindowHandle) {
+        // Close any existing editor
+        self.close();
+
+        let host = self.host.clone();
+        let parameters = self.parameters.clone();
+
+        let size = LogicalSize::new(Self::DEFAULT_SIZE.0, Self::DEFAULT_SIZE.1);
+        let window_attributes = WindowAttributes::new(size, 1.0);
+
+        self.editor_handle = Some(SlintEditor::open(parent, window_attributes, move |_window| {
+            EqPluginView::new(host.clone(), parameters.clone())
+        }));
+    }
+
+    fn close(&mut self) {
+        self.editor_handle = None;
+    }
+
+    fn on_frame(&mut self) {
+        if let Some(handle) = &self.editor_handle {
+            handle.on_frame();
+        }
+    }
+}

--- a/sotf-audio-plugins/src-slint/src/lib.rs
+++ b/sotf-audio-plugins/src-slint/src/lib.rs
@@ -1,0 +1,16 @@
+//! SOTF EQ Plugin with Slint UI
+//!
+//! A 4-band parametric equalizer using plinth-plugin framework and Slint UI.
+
+mod editor;
+mod parameters;
+mod plugin;
+mod processor;
+mod view;
+
+use plugin::SotfEqPlugin;
+use plinth_plugin::{export_clap, export_vst3};
+
+// Export the plugin for CLAP and VST3 formats
+export_clap!(SotfEqPlugin);
+export_vst3!(SotfEqPlugin);

--- a/sotf-audio-plugins/src-slint/src/parameters.rs
+++ b/sotf-audio-plugins/src-slint/src/parameters.rs
@@ -1,0 +1,278 @@
+//! EQ Plugin Parameters
+//!
+//! Defines all parameters for the 4-band parametric EQ using plinth-plugin's parameter system.
+
+use plinth_derive::ParameterKind;
+use plinth_plugin::{
+    BoolParameter, FloatFormatter, FloatParameter, LinearFloatRange, LogFloatRange,
+    Parameter, ParameterId, ParameterMap, Parameters,
+};
+use std::sync::Arc;
+
+/// Number of EQ bands
+pub const NUM_BANDS: usize = 4;
+
+/// Filter types available for each band
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FilterType {
+    #[default]
+    Peak,
+    LowShelf,
+    HighShelf,
+    LowPass,
+    HighPass,
+}
+
+impl FilterType {
+    pub fn name(&self) -> &'static str {
+        match self {
+            FilterType::Peak => "Peak",
+            FilterType::LowShelf => "Low Shelf",
+            FilterType::HighShelf => "High Shelf",
+            FilterType::LowPass => "Low Pass",
+            FilterType::HighPass => "High Pass",
+        }
+    }
+
+    pub fn from_index(index: usize) -> Self {
+        match index {
+            0 => FilterType::Peak,
+            1 => FilterType::LowShelf,
+            2 => FilterType::HighShelf,
+            3 => FilterType::LowPass,
+            4 => FilterType::HighPass,
+            _ => FilterType::Peak,
+        }
+    }
+
+    pub fn to_index(&self) -> usize {
+        match self {
+            FilterType::Peak => 0,
+            FilterType::LowShelf => 1,
+            FilterType::HighShelf => 2,
+            FilterType::LowPass => 3,
+            FilterType::HighPass => 4,
+        }
+    }
+}
+
+/// Parameter identifiers for the EQ plugin
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ParameterKind)]
+pub enum EqParameter {
+    // Band 1
+    Band1Enabled,
+    Band1Type,
+    Band1Frequency,
+    Band1Q,
+    Band1Gain,
+
+    // Band 2
+    Band2Enabled,
+    Band2Type,
+    Band2Frequency,
+    Band2Q,
+    Band2Gain,
+
+    // Band 3
+    Band3Enabled,
+    Band3Type,
+    Band3Frequency,
+    Band3Q,
+    Band3Gain,
+
+    // Band 4
+    Band4Enabled,
+    Band4Type,
+    Band4Frequency,
+    Band4Q,
+    Band4Gain,
+
+    // Output
+    OutputGain,
+}
+
+impl EqParameter {
+    /// Get band parameters by index
+    pub fn band_enabled(band: usize) -> Self {
+        match band {
+            0 => EqParameter::Band1Enabled,
+            1 => EqParameter::Band2Enabled,
+            2 => EqParameter::Band3Enabled,
+            _ => EqParameter::Band4Enabled,
+        }
+    }
+
+    pub fn band_type(band: usize) -> Self {
+        match band {
+            0 => EqParameter::Band1Type,
+            1 => EqParameter::Band2Type,
+            2 => EqParameter::Band3Type,
+            _ => EqParameter::Band4Type,
+        }
+    }
+
+    pub fn band_frequency(band: usize) -> Self {
+        match band {
+            0 => EqParameter::Band1Frequency,
+            1 => EqParameter::Band2Frequency,
+            2 => EqParameter::Band3Frequency,
+            _ => EqParameter::Band4Frequency,
+        }
+    }
+
+    pub fn band_q(band: usize) -> Self {
+        match band {
+            0 => EqParameter::Band1Q,
+            1 => EqParameter::Band2Q,
+            2 => EqParameter::Band3Q,
+            _ => EqParameter::Band4Q,
+        }
+    }
+
+    pub fn band_gain(band: usize) -> Self {
+        match band {
+            0 => EqParameter::Band1Gain,
+            1 => EqParameter::Band2Gain,
+            2 => EqParameter::Band3Gain,
+            _ => EqParameter::Band4Gain,
+        }
+    }
+}
+
+/// EQ plugin parameters container
+pub struct EqParameters {
+    map: ParameterMap,
+}
+
+impl Default for EqParameters {
+    fn default() -> Self {
+        let mut map = ParameterMap::new();
+
+        // Default frequencies for 4 bands: 100Hz, 500Hz, 2kHz, 8kHz
+        let default_freqs = [100.0, 500.0, 2000.0, 8000.0];
+
+        // Shared ranges (wrapped in Arc for reuse)
+        // LogFloatRange::new takes (min, max, k) where k is the logarithmic exponent (k > 1.0)
+        let type_range = Arc::new(LinearFloatRange::new(0.0, 4.0));
+        let freq_range = Arc::new(LogFloatRange::new(20.0, 20000.0, 10.0));
+        let q_range = Arc::new(LogFloatRange::new(0.1, 10.0, 10.0));
+        let gain_range = Arc::new(LinearFloatRange::new(-24.0, 24.0));
+
+        // Shared formatters
+        let type_formatter = Arc::new(FloatFormatter::new(0, ""));
+        let freq_formatter = Arc::new(FloatFormatter::new(0, " Hz"));
+        let q_formatter = Arc::new(FloatFormatter::new(2, ""));
+        let gain_formatter = Arc::new(FloatFormatter::new(1, " dB"));
+
+        // Add parameters for each band
+        for band in 0..NUM_BANDS {
+            let prefix = format!("Band {}", band + 1);
+
+            // Enabled
+            map.add(
+                BoolParameter::new(EqParameter::band_enabled(band), format!("{} Enabled", prefix))
+                    .with_default_value(true),
+            );
+
+            // Filter type (stored as float, 0-4 for 5 types)
+            map.add(
+                FloatParameter::new(
+                    EqParameter::band_type(band),
+                    format!("{} Type", prefix),
+                    type_range.clone(),
+                )
+                .with_default_value(0.0)
+                .with_formatter(type_formatter.clone()),
+            );
+
+            // Frequency (20Hz - 20kHz, logarithmic)
+            map.add(
+                FloatParameter::new(
+                    EqParameter::band_frequency(band),
+                    format!("{} Frequency", prefix),
+                    freq_range.clone(),
+                )
+                .with_default_value(default_freqs[band])
+                .with_formatter(freq_formatter.clone()),
+            );
+
+            // Q (0.1 - 10, logarithmic)
+            map.add(
+                FloatParameter::new(
+                    EqParameter::band_q(band),
+                    format!("{} Q", prefix),
+                    q_range.clone(),
+                )
+                .with_default_value(1.0)
+                .with_formatter(q_formatter.clone()),
+            );
+
+            // Gain (-24 to +24 dB)
+            map.add(
+                FloatParameter::new(
+                    EqParameter::band_gain(band),
+                    format!("{} Gain", prefix),
+                    gain_range.clone(),
+                )
+                .with_default_value(0.0)
+                .with_formatter(gain_formatter.clone()),
+            );
+        }
+
+        // Output gain
+        map.add(
+            FloatParameter::new(EqParameter::OutputGain, "Output Gain", gain_range)
+                .with_default_value(0.0)
+                .with_formatter(gain_formatter),
+        );
+
+        Self { map }
+    }
+}
+
+impl EqParameters {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Get band filter type
+    pub fn band_filter_type(&self, band: usize) -> FilterType {
+        let type_value: f64 = self.map.value::<FloatParameter>(EqParameter::band_type(band));
+        FilterType::from_index(type_value.round() as usize)
+    }
+
+    /// Get band frequency
+    pub fn band_frequency(&self, band: usize) -> f64 {
+        self.map.value::<FloatParameter>(EqParameter::band_frequency(band))
+    }
+
+    /// Get band Q
+    pub fn band_q(&self, band: usize) -> f64 {
+        self.map.value::<FloatParameter>(EqParameter::band_q(band))
+    }
+
+    /// Get band gain in dB
+    pub fn band_gain(&self, band: usize) -> f64 {
+        self.map.value::<FloatParameter>(EqParameter::band_gain(band))
+    }
+
+    /// Get band enabled
+    pub fn band_enabled(&self, band: usize) -> bool {
+        self.map.value::<BoolParameter>(EqParameter::band_enabled(band))
+    }
+
+    /// Get output gain in dB
+    pub fn output_gain(&self) -> f64 {
+        self.map.value::<FloatParameter>(EqParameter::OutputGain)
+    }
+}
+
+impl Parameters for EqParameters {
+    fn ids(&self) -> &[ParameterId] {
+        self.map.ids()
+    }
+
+    fn get(&self, id: impl Into<ParameterId>) -> Option<&dyn Parameter> {
+        self.map.get(id)
+    }
+}

--- a/sotf-audio-plugins/src-slint/src/plugin.rs
+++ b/sotf-audio-plugins/src-slint/src/plugin.rs
@@ -1,0 +1,84 @@
+//! SOTF EQ Plugin Implementation
+//!
+//! A 4-band parametric equalizer using plinth-plugin with Slint UI.
+
+use crate::editor::EqPluginEditor;
+use crate::parameters::EqParameters;
+use crate::processor::EqProcessor;
+use plinth_plugin::{
+    clap::{ClapPlugin, Feature as ClapFeature},
+    vst3::{Subcategory as Vst3Subcategory, Vst3Plugin},
+    Error, Event, Host, HostInfo, Plugin, ProcessorConfig,
+};
+use std::io::{Read, Write};
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// SOTF Parametric EQ Plugin
+pub struct SotfEqPlugin {
+    /// Plugin parameters
+    parameters: Arc<EqParameters>,
+}
+
+impl Plugin for SotfEqPlugin {
+    const NAME: &'static str = "SOTF EQ";
+    const VENDOR: &'static str = "SOTF";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+    type Processor = EqProcessor;
+    type Editor = EqPluginEditor;
+    type Parameters = EqParameters;
+
+    fn new(_host_info: HostInfo) -> Self {
+        Self {
+            parameters: EqParameters::new(),
+        }
+    }
+
+    fn with_parameters<T>(&self, f: impl FnMut(&Self::Parameters) -> T) -> T {
+        let mut f = f;
+        f(&self.parameters)
+    }
+
+    fn process_event(&mut self, _event: &Event) {
+        // Parameters are handled automatically via the parameter system
+    }
+
+    fn create_processor(&mut self, config: ProcessorConfig) -> Self::Processor {
+        EqProcessor::new(self.parameters.clone(), config.sample_rate)
+    }
+
+    fn create_editor(&mut self, host: Rc<dyn Host>) -> Self::Editor {
+        EqPluginEditor::new(host, self.parameters.clone())
+    }
+
+    fn save_state(&self, _writer: &mut impl Write) -> Result<(), Error> {
+        // State is saved via the parameter system automatically
+        Ok(())
+    }
+
+    fn load_state(&mut self, _reader: &mut impl Read) -> Result<(), Error> {
+        // State is loaded via the parameter system automatically
+        Ok(())
+    }
+}
+
+impl ClapPlugin for SotfEqPlugin {
+    const CLAP_ID: &'static str = "org.spinorama.sotf-eq-slint";
+
+    const FEATURES: &'static [ClapFeature] = &[
+        ClapFeature::AudioEffect,
+        ClapFeature::Stereo,
+        ClapFeature::Mono,
+        ClapFeature::Equalizer,
+    ];
+}
+
+impl Vst3Plugin for SotfEqPlugin {
+    // Convert "SOTFEqSlint001\0\0" to u128
+    // The bytes are: S O T F E q S l i n t 0 0 1 \0 \0
+    const CLASS_ID: u128 = u128::from_be_bytes(*b"SOTFEqSlint001\0\0");
+
+    const SUBCATEGORIES: &'static [Vst3Subcategory] =
+        &[Vst3Subcategory::Fx, Vst3Subcategory::Eq];
+}

--- a/sotf-audio-plugins/src-slint/src/processor.rs
+++ b/sotf-audio-plugins/src-slint/src/processor.rs
@@ -1,0 +1,137 @@
+//! EQ Plugin Audio Processor
+//!
+//! Processes audio through 4-band parametric EQ using biquad filters.
+
+use crate::parameters::{EqParameters, FilterType, NUM_BANDS};
+use autoeq_iir::{Biquad, BiquadFilterType};
+use plinth_plugin::plinth_core::signals::signal::{Signal, SignalMut};
+use plinth_plugin::{Event, ProcessState, Processor, Transport};
+use std::sync::Arc;
+
+/// Maximum number of channels supported
+const MAX_CHANNELS: usize = 2;
+
+/// EQ Plugin Processor
+pub struct EqProcessor {
+    /// Plugin parameters
+    parameters: Arc<EqParameters>,
+
+    /// Biquad filters for each band and channel
+    /// Indexed as [band][channel]
+    filters: [[Biquad; MAX_CHANNELS]; NUM_BANDS],
+
+    /// Current sample rate
+    sample_rate: f64,
+}
+
+impl EqProcessor {
+    pub fn new(parameters: Arc<EqParameters>, sample_rate: f64) -> Self {
+        let filters = std::array::from_fn(|_| {
+            std::array::from_fn(|_| {
+                Biquad::new(BiquadFilterType::Peak, 1000.0, sample_rate, 1.0, 0.0)
+            })
+        });
+
+        let mut processor = Self {
+            parameters,
+            filters,
+            sample_rate,
+        };
+
+        // Initialize filters with current parameter values
+        processor.update_all_filters();
+        processor
+    }
+
+    /// Convert our FilterType enum to autoeq_iir's BiquadFilterType
+    fn convert_filter_type(filter_type: FilterType) -> BiquadFilterType {
+        match filter_type {
+            FilterType::Peak => BiquadFilterType::Peak,
+            FilterType::LowShelf => BiquadFilterType::Lowshelf,
+            FilterType::HighShelf => BiquadFilterType::Highshelf,
+            FilterType::LowPass => BiquadFilterType::Lowpass,
+            FilterType::HighPass => BiquadFilterType::Highpass,
+        }
+    }
+
+    /// Update filter coefficients for a specific band
+    fn update_filter(&mut self, band_index: usize) {
+        let filter_type = Self::convert_filter_type(self.parameters.band_filter_type(band_index));
+        let frequency = self.parameters.band_frequency(band_index);
+        let q = self.parameters.band_q(band_index);
+        let gain_db = self.parameters.band_gain(band_index);
+
+        for channel in 0..MAX_CHANNELS {
+            self.filters[band_index][channel] =
+                Biquad::new(filter_type, frequency, self.sample_rate, q, gain_db);
+        }
+    }
+
+    /// Update all filter coefficients
+    fn update_all_filters(&mut self) {
+        for band_index in 0..NUM_BANDS {
+            self.update_filter(band_index);
+        }
+    }
+
+    /// Convert dB to linear amplitude
+    fn db_to_amplitude(db: f64) -> f64 {
+        10.0_f64.powf(db / 20.0)
+    }
+}
+
+impl Processor for EqProcessor {
+    fn reset(&mut self) {
+        // Reset filter state by recreating them
+        self.update_all_filters();
+    }
+
+    fn process(
+        &mut self,
+        buffer: &mut impl SignalMut,
+        _aux: Option<&impl Signal>,
+        _transport: Option<Transport>,
+        events: impl Iterator<Item = Event>,
+    ) -> ProcessState {
+        // Process parameter change events (currently unused, parameters auto-sync)
+        for _event in events {
+            // Parameters are updated via the parameter system
+        }
+
+        // Update filters (in a more optimized version, we'd track parameter changes)
+        self.update_all_filters();
+
+        // Get output gain as linear amplitude
+        let output_gain = Self::db_to_amplitude(self.parameters.output_gain()) as f32;
+
+        let num_channels = buffer.channels().min(MAX_CHANNELS);
+        let num_frames = buffer.len();
+
+        // Process each channel
+        for channel_idx in 0..num_channels {
+            let channel = buffer.channel_mut(channel_idx);
+
+            for frame_idx in 0..num_frames {
+                let mut value = channel[frame_idx] as f64;
+
+                // Apply each enabled band's filter
+                for band_index in 0..NUM_BANDS {
+                    if self.parameters.band_enabled(band_index) {
+                        value = self.filters[band_index][channel_idx].process(value);
+                    }
+                }
+
+                // Apply output gain
+                channel[frame_idx] = (value as f32) * output_gain;
+            }
+        }
+
+        ProcessState::Normal
+    }
+
+    fn process_events(&mut self, events: impl Iterator<Item = Event>) {
+        for _event in events {
+            // Parameters are updated via the parameter system
+        }
+    }
+}

--- a/sotf-audio-plugins/src-slint/src/view.rs
+++ b/sotf-audio-plugins/src-slint/src/view.rs
@@ -1,0 +1,126 @@
+//! EQ Plugin View
+//!
+//! Connects the Slint UI with the plugin parameters and host.
+
+use crate::parameters::{EqParameters, NUM_BANDS};
+use plinth_plugin::Host;
+use plugin_canvas::{event::EventResponse, Event};
+use plugin_canvas_slint::view::PluginView;
+use std::rc::Rc;
+use std::sync::Arc;
+
+slint::include_modules!();
+
+/// EQ Plugin View wrapping the Slint UI
+pub struct EqPluginView {
+    plugin_window: PluginWindow,
+    parameters: Arc<EqParameters>,
+}
+
+impl EqPluginView {
+    pub fn new(host: Rc<dyn Host>, parameters: Arc<EqParameters>) -> Self {
+        let plugin_window = PluginWindow::new().expect("Failed to create Slint window");
+
+        // Set up parameter change callbacks
+        let host_start = host.clone();
+        plugin_window.on_start_parameter_change(move |param_id| {
+            host_start.start_parameter_change(param_id as u32);
+        });
+
+        let host_change = host.clone();
+        plugin_window.on_change_parameter_value(move |param_id, normalized_value| {
+            host_change.change_parameter_value(param_id as u32, normalized_value as f64);
+        });
+
+        let host_end = host.clone();
+        plugin_window.on_end_parameter_change(move |param_id| {
+            host_end.end_parameter_change(param_id as u32);
+        });
+
+        Self {
+            plugin_window,
+            parameters,
+        }
+    }
+
+    /// Update UI with current parameter values
+    fn update_ui(&self) {
+        // Update each band
+        for band in 0..NUM_BANDS {
+            let freq = self.parameters.band_frequency(band);
+            let q = self.parameters.band_q(band);
+            let gain = self.parameters.band_gain(band);
+
+            let band_data = BandData {
+                enabled: self.parameters.band_enabled(band),
+                filter_type: self.parameters.band_filter_type(band).to_index() as i32,
+                frequency: freq as f32,
+                frequency_normalized: freq_to_normalized(freq) as f32,
+                q: q as f32,
+                q_normalized: q_to_normalized(q) as f32,
+                gain_db: gain as f32,
+                gain_normalized: ((gain + 24.0) / 48.0) as f32,
+                frequency_text: format_frequency(freq).into(),
+                q_text: format!("{:.2}", q).into(),
+                gain_text: format!("{:.1} dB", gain).into(),
+            };
+
+            match band {
+                0 => self.plugin_window.set_band1_data(band_data),
+                1 => self.plugin_window.set_band2_data(band_data),
+                2 => self.plugin_window.set_band3_data(band_data),
+                _ => self.plugin_window.set_band4_data(band_data),
+            }
+        }
+
+        // Update output gain
+        let output_gain = self.parameters.output_gain();
+        self.plugin_window.set_output_gain(output_gain as f32);
+        self.plugin_window.set_output_gain_normalized(((output_gain + 24.0) / 48.0) as f32);
+        self.plugin_window
+            .set_output_gain_text(format!("{:.1} dB", output_gain).into());
+    }
+}
+
+impl PluginView for EqPluginView {
+    fn window(&self) -> &slint::Window {
+        self.plugin_window.window()
+    }
+
+    fn on_event(&self, event: &Event) -> EventResponse {
+        match event {
+            Event::Draw => {
+                self.update_ui();
+                EventResponse::Handled
+            }
+            _ => EventResponse::Ignored,
+        }
+    }
+}
+
+/// Convert frequency to normalized (0-1) using log scale
+fn freq_to_normalized(freq: f64) -> f64 {
+    let min_freq = 20.0_f64;
+    let max_freq = 20000.0_f64;
+    let log_min = min_freq.ln();
+    let log_max = max_freq.ln();
+    (freq.ln() - log_min) / (log_max - log_min)
+}
+
+/// Convert Q to normalized (0-1) using log scale
+fn q_to_normalized(q: f64) -> f64 {
+    let min_q = 0.1_f64;
+    let max_q = 10.0_f64;
+    let log_min = min_q.ln();
+    let log_max = max_q.ln();
+    (q.ln() - log_min) / (log_max - log_min)
+}
+
+/// Format frequency for display
+fn format_frequency(freq: f64) -> String {
+    if freq >= 1000.0 {
+        format!("{:.1} kHz", freq / 1000.0)
+    } else {
+        format!("{:.0} Hz", freq)
+    }
+}

--- a/sotf-audio-plugins/src-slint/ui/main.slint
+++ b/sotf-audio-plugins/src-slint/ui/main.slint
@@ -1,0 +1,549 @@
+// SOTF EQ Plugin UI
+// A 4-band parametric equalizer with frequency response visualization
+
+import { VerticalBox, HorizontalBox, Button, ComboBox, CheckBox, Slider, GroupBox } from "std-widgets.slint";
+
+// Color palette matching the egui version
+struct BandColors {
+    band1: color,
+    band2: color,
+    band3: color,
+    band4: color,
+}
+
+// UI parameter for host communication
+export struct UiParameter {
+    id: int,
+    normalized-value: float,
+    default-value: float,
+    display-text: string,
+}
+
+// Band data for display
+export struct BandData {
+    enabled: bool,
+    filter-type: int,
+    frequency: float,
+    frequency-normalized: float,
+    q: float,
+    q-normalized: float,
+    gain-db: float,
+    gain-normalized: float,
+    // For display
+    frequency-text: string,
+    q-text: string,
+    gain-text: string,
+}
+
+// Main plugin window
+export component PluginWindow inherits Window {
+    title: "SOTF EQ";
+    min-width: 800px;
+    min-height: 500px;
+    background: #19191e;
+
+    // Band colors
+    property <BandColors> colors: {
+        band1: #ef4444,  // Red
+        band2: #f97316,  // Orange
+        band3: #22c55e,  // Green
+        band4: #3b82f6,  // Blue
+    };
+
+    // Currently selected band (0-3)
+    in-out property <int> selected-band: 0;
+
+    // Band data
+    in-out property <BandData> band1-data;
+    in-out property <BandData> band2-data;
+    in-out property <BandData> band3-data;
+    in-out property <BandData> band4-data;
+
+    // Output gain
+    in-out property <float> output-gain: 0.0;
+    in-out property <float> output-gain-normalized: 0.5;
+    in-out property <string> output-gain-text: "0.0 dB";
+
+    // Callbacks to host
+    callback start-parameter-change(int);
+    callback change-parameter-value(int, float);
+    callback end-parameter-change(int);
+
+    // Helper function to get band color
+    function band-color(index: int) -> color {
+        if index == 0 { return colors.band1; }
+        if index == 1 { return colors.band2; }
+        if index == 2 { return colors.band3; }
+        return colors.band4;
+    }
+
+    // Helper to get current band data
+    function current-band() -> BandData {
+        if selected-band == 0 { return band1-data; }
+        if selected-band == 1 { return band2-data; }
+        if selected-band == 2 { return band3-data; }
+        return band4-data;
+    }
+
+    VerticalBox {
+        padding: 15px;
+        spacing: 10px;
+
+        // Header
+        HorizontalBox {
+            alignment: start;
+            spacing: 10px;
+
+            Text {
+                text: "SOTF EQ";
+                font-size: 20px;
+                font-weight: 700;
+                color: #e0e0e5;
+            }
+
+            Rectangle {
+                width: 1px;
+                height: 24px;
+                background: #404045;
+            }
+
+            Text {
+                text: "4-Band Parametric Equalizer";
+                font-size: 14px;
+                color: #808090;
+                vertical-alignment: center;
+            }
+        }
+
+        // Frequency response graph area
+        Rectangle {
+            background: #14141a;
+            border-radius: 5px;
+            min-height: 250px;
+
+            // Frequency labels at bottom
+            HorizontalBox {
+                y: parent.height - 20px;
+                x: 0;
+                width: 100%;
+                padding-left: 5px;
+                padding-right: 5px;
+
+                for freq in ["20", "50", "100", "200", "500", "1k", "2k", "5k", "10k", "20k"]: Text {
+                    text: freq;
+                    font-size: 10px;
+                    color: #606070;
+                    horizontal-alignment: center;
+                }
+            }
+
+            // 0dB line indicator
+            Rectangle {
+                y: parent.height / 2;
+                x: 0;
+                width: 100%;
+                height: 1px;
+                background: #505055;
+            }
+
+            // Gain labels
+            VerticalBox {
+                x: 5px;
+                y: 10px;
+                spacing: 30px;
+
+                Text { text: "+24"; font-size: 10px; color: #606070; }
+                Text { text: "+12"; font-size: 10px; color: #606070; }
+                Text { text: "0 dB"; font-size: 10px; color: #808090; }
+                Text { text: "-12"; font-size: 10px; color: #606070; }
+                Text { text: "-24"; font-size: 10px; color: #606070; }
+            }
+
+            // Note: Actual response curves drawn by Rust via image/path
+            Text {
+                x: parent.width / 2 - self.width / 2;
+                y: parent.height / 2 - 30px;
+                text: "(Response graph rendered by backend)";
+                font-size: 12px;
+                color: #404050;
+            }
+        }
+
+        // Band selector and output gain
+        HorizontalBox {
+            spacing: 10px;
+            alignment: start;
+
+            // Band tabs
+            for i in [0, 1, 2, 3]: Rectangle {
+                width: 80px;
+                height: 32px;
+                border-radius: 4px;
+                background: selected-band == i ? band-color(i) : #323237;
+
+                Text {
+                    text: "Band " + (i + 1);
+                    font-size: 13px;
+                    font-weight: selected-band == i ? 600 : 400;
+                    color: selected-band == i ? #ffffff : #a0a0a5;
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+
+                TouchArea {
+                    clicked => {
+                        selected-band = i;
+                    }
+                }
+            }
+
+            Rectangle {
+                width: 1px;
+                height: 32px;
+                background: #404045;
+            }
+
+            // Output gain
+            HorizontalBox {
+                spacing: 8px;
+                alignment: center;
+
+                Text {
+                    text: "Output:";
+                    font-size: 13px;
+                    color: #a0a0a5;
+                    vertical-alignment: center;
+                }
+
+                Rectangle {
+                    width: 100px;
+                    height: 28px;
+                    background: #28282d;
+                    border-radius: 4px;
+
+                    Text {
+                        text: output-gain-text;
+                        font-size: 13px;
+                        color: #e0e0e5;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+
+                    // Draggable output gain control
+                    property <float> drag-start-value;
+                    property <length> last-y;
+                    property <bool> is-dragging: false;
+
+                    TouchArea {
+                        mouse-cursor: pointer;
+
+                        scroll-event(event) => {
+                            // Scroll wheel adjusts gain
+                            let delta = event.delta-y / 50px;
+                            let new-norm = clamp(output-gain-normalized + delta, 0.0, 1.0);
+                            start-parameter-change(20);
+                            change-parameter-value(20, new-norm);
+                            end-parameter-change(20);
+                            accept
+                        }
+
+                        pointer-event(event) => {
+                            if event.kind == PointerEventKind.down {
+                                parent.drag-start-value = output-gain-normalized;
+                                parent.is-dragging = true;
+                                start-parameter-change(20);
+                            } else if event.kind == PointerEventKind.up {
+                                parent.is-dragging = false;
+                                end-parameter-change(20);
+                            }
+                        }
+
+                        moved => {
+                            if parent.is-dragging {
+                                // Calculate delta from center of control
+                                let delta = (parent.height / 2 - self.mouse-y) / 100px;
+                                let new-norm = clamp(parent.drag-start-value + delta, 0.0, 1.0);
+                                change-parameter-value(20, new-norm);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Band controls
+        Rectangle {
+            background: #232328;
+            border-radius: 8px;
+            height: 120px;
+
+            HorizontalBox {
+                padding: 15px;
+                spacing: 20px;
+
+                // Enabled checkbox
+                VerticalBox {
+                    alignment: center;
+                    spacing: 5px;
+
+                    CheckBox {
+                        text: "Enabled";
+                        checked: current-band().enabled;
+                        toggled => {
+                            let param-id = selected-band * 5;
+                            start-parameter-change(param-id);
+                            change-parameter-value(param-id, self.checked ? 1.0 : 0.0);
+                            end-parameter-change(param-id);
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: 1px;
+                    background: #404045;
+                }
+
+                // Filter type
+                VerticalBox {
+                    alignment: center;
+                    spacing: 5px;
+
+                    Text {
+                        text: "Type";
+                        font-size: 12px;
+                        color: #808090;
+                    }
+
+                    ComboBox {
+                        width: 100px;
+                        model: ["Peak", "Low Shelf", "High Shelf", "Low Pass", "High Pass"];
+                        current-index: current-band().filter-type;
+                        selected(new-value) => {
+                            let param-id = selected-band * 5 + 1;
+                            // current-index is already updated, use it for normalized value
+                            let norm = self.current-index / 4.0;
+                            start-parameter-change(param-id);
+                            change-parameter-value(param-id, norm);
+                            end-parameter-change(param-id);
+                        }
+                    }
+                }
+
+                // Frequency control
+                VerticalBox {
+                    alignment: center;
+                    spacing: 5px;
+
+                    Text {
+                        text: "Frequency";
+                        font-size: 12px;
+                        color: #808090;
+                    }
+
+                    Rectangle {
+                        width: 90px;
+                        height: 32px;
+                        background: #28282d;
+                        border-radius: 4px;
+
+                        Text {
+                            text: current-band().frequency-text;
+                            font-size: 13px;
+                            color: #e0e0e5;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+
+                        property <float> drag-start-value;
+                        property <bool> is-dragging: false;
+
+                        TouchArea {
+                            mouse-cursor: pointer;
+
+                            scroll-event(event) => {
+                                let delta = event.delta-y / 200px;
+                                let new-norm = clamp(current-band().frequency-normalized + delta, 0.0, 1.0);
+                                let param-id = selected-band * 5 + 2;
+                                start-parameter-change(param-id);
+                                change-parameter-value(param-id, new-norm);
+                                end-parameter-change(param-id);
+                                accept
+                            }
+
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down {
+                                    parent.drag-start-value = current-band().frequency-normalized;
+                                    parent.is-dragging = true;
+                                    let param-id = selected-band * 5 + 2;
+                                    start-parameter-change(param-id);
+                                }
+                                if event.kind == PointerEventKind.up {
+                                    parent.is-dragging = false;
+                                    let param-id = selected-band * 5 + 2;
+                                    end-parameter-change(param-id);
+                                }
+                            }
+
+                            moved => {
+                                if parent.is-dragging {
+                                    let delta = (parent.height / 2 - self.mouse-y) / 100px;
+                                    let new-norm = clamp(parent.drag-start-value + delta, 0.0, 1.0);
+                                    let param-id = selected-band * 5 + 2;
+                                    change-parameter-value(param-id, new-norm);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Q control
+                VerticalBox {
+                    alignment: center;
+                    spacing: 5px;
+
+                    Text {
+                        text: "Q";
+                        font-size: 12px;
+                        color: #808090;
+                    }
+
+                    Rectangle {
+                        width: 70px;
+                        height: 32px;
+                        background: #28282d;
+                        border-radius: 4px;
+
+                        Text {
+                            text: current-band().q-text;
+                            font-size: 13px;
+                            color: #e0e0e5;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+
+                        property <float> drag-start-value;
+                        property <bool> is-dragging: false;
+
+                        TouchArea {
+                            mouse-cursor: pointer;
+
+                            scroll-event(event) => {
+                                let delta = event.delta-y / 200px;
+                                let new-norm = clamp(current-band().q-normalized + delta, 0.0, 1.0);
+                                let param-id = selected-band * 5 + 3;
+                                start-parameter-change(param-id);
+                                change-parameter-value(param-id, new-norm);
+                                end-parameter-change(param-id);
+                                accept
+                            }
+
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down {
+                                    parent.drag-start-value = current-band().q-normalized;
+                                    parent.is-dragging = true;
+                                    let param-id = selected-band * 5 + 3;
+                                    start-parameter-change(param-id);
+                                }
+                                if event.kind == PointerEventKind.up {
+                                    parent.is-dragging = false;
+                                    let param-id = selected-band * 5 + 3;
+                                    end-parameter-change(param-id);
+                                }
+                            }
+
+                            moved => {
+                                if parent.is-dragging {
+                                    let delta = (parent.height / 2 - self.mouse-y) / 100px;
+                                    let new-norm = clamp(parent.drag-start-value + delta, 0.0, 1.0);
+                                    let param-id = selected-band * 5 + 3;
+                                    change-parameter-value(param-id, new-norm);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Gain control
+                VerticalBox {
+                    alignment: center;
+                    spacing: 5px;
+
+                    Text {
+                        text: "Gain";
+                        font-size: 12px;
+                        color: #808090;
+                    }
+
+                    Rectangle {
+                        width: 80px;
+                        height: 32px;
+                        background: #28282d;
+                        border-radius: 4px;
+
+                        Text {
+                            text: current-band().gain-text;
+                            font-size: 13px;
+                            color: #e0e0e5;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+
+                        property <float> drag-start-value;
+                        property <bool> is-dragging: false;
+
+                        TouchArea {
+                            mouse-cursor: pointer;
+
+                            scroll-event(event) => {
+                                let delta = event.delta-y / 100px;
+                                let new-norm = clamp(current-band().gain-normalized + delta, 0.0, 1.0);
+                                let param-id = selected-band * 5 + 4;
+                                start-parameter-change(param-id);
+                                change-parameter-value(param-id, new-norm);
+                                end-parameter-change(param-id);
+                                accept
+                            }
+
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down {
+                                    parent.drag-start-value = current-band().gain-normalized;
+                                    parent.is-dragging = true;
+                                    let param-id = selected-band * 5 + 4;
+                                    start-parameter-change(param-id);
+                                }
+                                if event.kind == PointerEventKind.up {
+                                    parent.is-dragging = false;
+                                    let param-id = selected-band * 5 + 4;
+                                    end-parameter-change(param-id);
+                                }
+                            }
+
+                            moved => {
+                                if parent.is-dragging {
+                                    let delta = (parent.height / 2 - self.mouse-y) / 80px;
+                                    let new-norm = clamp(parent.drag-start-value + delta, 0.0, 1.0);
+                                    let param-id = selected-band * 5 + 4;
+                                    change-parameter-value(param-id, new-norm);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Band color indicator
+                Rectangle {
+                    width: 1px;
+                    background: transparent;
+                    horizontal-stretch: 1;
+                }
+
+                Rectangle {
+                    width: 40px;
+                    height: 40px;
+                    border-radius: 20px;
+                    background: band-color(selected-band);
+                }
+            }
+        }
+    }
+}

--- a/sotf-audio-plugins/src-vst3/Cargo.toml
+++ b/sotf-audio-plugins/src-vst3/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "sotf-audio-plugins-vst3"
+version = "0.5.1"
+edition = { workspace = true }
+authors = { workspace = true }
+description = "VST3/CLAP wrapper for SOTF audio plugins using nih-plug"
+license = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# nih-plug for VST3/CLAP
+nih_plug = { workspace = true }
+nih_plug_egui = { workspace = true }
+
+# SOTF plugins and audio processing
+sotf-audio-plugins = { workspace = true }
+autoeq-iir = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Utilities
+log = { workspace = true }
+parking_lot = { workspace = true }

--- a/sotf-audio-plugins/src-vst3/src/editor/eq_view.rs
+++ b/sotf-audio-plugins/src-vst3/src/editor/eq_view.rs
@@ -1,0 +1,477 @@
+//! EQ Visualization View
+//!
+//! egui-based EQ visualization with frequency response graph and band controls.
+
+use crate::eq_params::{FilterType, SotfEqParams, NUM_BANDS};
+use autoeq_iir::{Biquad, BiquadFilterType};
+use nih_plug::prelude::*;
+use nih_plug_egui::egui::{self, Color32, Pos2, Rect, Stroke, Vec2};
+use std::sync::Arc;
+
+/// Sample rate for filter calculations
+const SAMPLE_RATE: f64 = 48000.0;
+
+/// Number of frequency points for response curve
+const NUM_FREQ_POINTS: usize = 256;
+
+/// Band colors (matching the GPUI version)
+const BAND_COLORS: [Color32; 4] = [
+    Color32::from_rgb(239, 68, 68),   // Red
+    Color32::from_rgb(249, 115, 22),  // Orange
+    Color32::from_rgb(34, 197, 94),   // Green
+    Color32::from_rgb(59, 130, 246),  // Blue
+];
+
+/// EQ Editor state
+pub struct EqEditorState {
+    params: Arc<SotfEqParams>,
+    selected_band: usize,
+    /// Cached frequency points (log scale from 20Hz to 20kHz)
+    freq_points: Vec<f64>,
+}
+
+impl EqEditorState {
+    pub fn new(params: Arc<SotfEqParams>) -> Self {
+        // Pre-compute logarithmically spaced frequency points
+        let min_freq = 20.0_f64;
+        let max_freq = 20000.0_f64;
+        let freq_points: Vec<f64> = (0..NUM_FREQ_POINTS)
+            .map(|i| {
+                let t = i as f64 / (NUM_FREQ_POINTS - 1) as f64;
+                let log_min = min_freq.ln();
+                let log_max = max_freq.ln();
+                (log_min + t * (log_max - log_min)).exp()
+            })
+            .collect();
+
+        Self {
+            params,
+            selected_band: 0,
+            freq_points,
+        }
+    }
+
+    /// Main UI rendering
+    pub fn ui(&mut self, ctx: &egui::Context, setter: &ParamSetter) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.vertical(|ui| {
+                // Header
+                ui.horizontal(|ui| {
+                    ui.heading("SOTF EQ");
+                    ui.separator();
+                    ui.label("4-Band Parametric Equalizer");
+                });
+
+                ui.add_space(10.0);
+
+                // Frequency response graph
+                self.draw_frequency_response(ui);
+
+                ui.add_space(10.0);
+
+                // Band selector and controls
+                ui.horizontal(|ui| {
+                    // Band tabs
+                    for band_idx in 0..NUM_BANDS {
+                        let is_selected = self.selected_band == band_idx;
+                        let color = BAND_COLORS[band_idx];
+
+                        let button = egui::Button::new(format!("Band {}", band_idx + 1))
+                            .fill(if is_selected {
+                                color
+                            } else {
+                                Color32::from_rgb(50, 50, 55)
+                            });
+
+                        if ui.add(button).clicked() {
+                            self.selected_band = band_idx;
+                        }
+                    }
+
+                    ui.separator();
+
+                    // Output gain control
+                    ui.label("Output:");
+                    let mut output_gain = self.params.output_gain.value();
+                    if ui
+                        .add(
+                            egui::DragValue::new(&mut output_gain)
+                                .range(-24.0..=24.0)
+                                .speed(0.1)
+                                .suffix(" dB"),
+                        )
+                        .changed()
+                    {
+                        setter.set_parameter(&self.params.output_gain, output_gain);
+                    }
+                });
+
+                ui.add_space(10.0);
+
+                // Selected band controls
+                self.draw_band_controls(ui, setter);
+            });
+        });
+    }
+
+    /// Draw the frequency response graph
+    fn draw_frequency_response(&self, ui: &mut egui::Ui) {
+        let available_width = ui.available_width();
+        let graph_height = 250.0;
+
+        let (response, painter) =
+            ui.allocate_painter(Vec2::new(available_width, graph_height), egui::Sense::hover());
+        let rect = response.rect;
+
+        // Draw background
+        painter.rect_filled(rect, 5.0, Color32::from_rgb(20, 20, 25));
+
+        // Draw grid
+        self.draw_grid(&painter, rect);
+
+        // Calculate and draw response curves
+        self.draw_response_curves(&painter, rect);
+    }
+
+    /// Draw the frequency/gain grid
+    fn draw_grid(&self, painter: &egui::Painter, rect: Rect) {
+        let grid_color = Color32::from_rgb(50, 50, 55);
+        let text_color = Color32::from_rgb(120, 120, 130);
+
+        // Frequency grid lines (logarithmic)
+        let freq_labels = [20.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0];
+        for freq in freq_labels {
+            let x = self.freq_to_x(freq, rect);
+            painter.line_segment(
+                [Pos2::new(x, rect.top()), Pos2::new(x, rect.bottom())],
+                Stroke::new(1.0, grid_color),
+            );
+
+            // Label
+            let label = if freq >= 1000.0 {
+                format!("{}k", (freq / 1000.0) as i32)
+            } else {
+                format!("{}", freq as i32)
+            };
+            painter.text(
+                Pos2::new(x, rect.bottom() - 15.0),
+                egui::Align2::CENTER_CENTER,
+                label,
+                egui::FontId::proportional(10.0),
+                text_color,
+            );
+        }
+
+        // Gain grid lines
+        let gain_labels = [-24.0, -18.0, -12.0, -6.0, 0.0, 6.0, 12.0, 18.0, 24.0];
+        for gain in gain_labels {
+            let y = self.gain_to_y(gain, rect);
+            let stroke = if gain == 0.0 {
+                Stroke::new(1.5, Color32::from_rgb(80, 80, 85))
+            } else {
+                Stroke::new(1.0, grid_color)
+            };
+            painter.line_segment(
+                [Pos2::new(rect.left(), y), Pos2::new(rect.right(), y)],
+                stroke,
+            );
+
+            // Label
+            if gain.abs() < 0.1 || gain.abs() > 20.0 {
+                painter.text(
+                    Pos2::new(rect.left() + 20.0, y),
+                    egui::Align2::LEFT_CENTER,
+                    format!("{:+.0} dB", gain),
+                    egui::FontId::proportional(10.0),
+                    text_color,
+                );
+            }
+        }
+    }
+
+    /// Draw the frequency response curves
+    fn draw_response_curves(&self, painter: &egui::Painter, rect: Rect) {
+        // Calculate individual band responses
+        let mut band_responses: Vec<Vec<f64>> = Vec::with_capacity(NUM_BANDS);
+        let mut combined_response: Vec<f64> = vec![0.0; NUM_FREQ_POINTS];
+
+        for band_idx in 0..NUM_BANDS {
+            let band = self.params.band(band_idx);
+            let enabled = band.enabled.value();
+
+            let response: Vec<f64> = self
+                .freq_points
+                .iter()
+                .map(|&freq| {
+                    if enabled {
+                        let biquad = Biquad::new(
+                            convert_filter_type(band.filter_type.value()),
+                            band.frequency.value() as f64,
+                            SAMPLE_RATE,
+                            band.q.value() as f64,
+                            band.gain_db.value() as f64,
+                        );
+                        biquad.log_result(freq)
+                    } else {
+                        0.0
+                    }
+                })
+                .collect();
+
+            // Add to combined response
+            for (i, &r) in response.iter().enumerate() {
+                combined_response[i] += r;
+            }
+
+            band_responses.push(response);
+        }
+
+        // Draw individual band curves (semi-transparent)
+        for (band_idx, response) in band_responses.iter().enumerate() {
+            let band = self.params.band(band_idx);
+            if !band.enabled.value() {
+                continue;
+            }
+
+            let color = BAND_COLORS[band_idx];
+            let alpha = if band_idx == self.selected_band {
+                180
+            } else {
+                80
+            };
+            let stroke_width = if band_idx == self.selected_band {
+                2.0
+            } else {
+                1.5
+            };
+
+            let points: Vec<Pos2> = self
+                .freq_points
+                .iter()
+                .zip(response.iter())
+                .map(|(&freq, &gain)| {
+                    Pos2::new(self.freq_to_x(freq, rect), self.gain_to_y(gain, rect))
+                })
+                .collect();
+
+            for window in points.windows(2) {
+                painter.line_segment(
+                    [window[0], window[1]],
+                    Stroke::new(stroke_width, color.gamma_multiply(alpha as f32 / 255.0)),
+                );
+            }
+        }
+
+        // Draw combined response curve (white, on top)
+        let combined_points: Vec<Pos2> = self
+            .freq_points
+            .iter()
+            .zip(combined_response.iter())
+            .map(|(&freq, &gain)| {
+                Pos2::new(self.freq_to_x(freq, rect), self.gain_to_y(gain, rect))
+            })
+            .collect();
+
+        for window in combined_points.windows(2) {
+            painter.line_segment(
+                [window[0], window[1]],
+                Stroke::new(2.5, Color32::from_rgb(200, 200, 210)),
+            );
+        }
+
+        // Draw band center frequency markers
+        for band_idx in 0..NUM_BANDS {
+            let band = self.params.band(band_idx);
+            if !band.enabled.value() {
+                continue;
+            }
+
+            let freq = band.frequency.value() as f64;
+            let x = self.freq_to_x(freq, rect);
+            let y = self.gain_to_y(band.gain_db.value() as f64, rect);
+
+            let color = BAND_COLORS[band_idx];
+            let radius = if band_idx == self.selected_band {
+                8.0
+            } else {
+                5.0
+            };
+
+            painter.circle_filled(Pos2::new(x, y), radius, color);
+            painter.circle_stroke(
+                Pos2::new(x, y),
+                radius,
+                Stroke::new(2.0, Color32::WHITE),
+            );
+        }
+    }
+
+    /// Draw controls for the selected band
+    fn draw_band_controls(&mut self, ui: &mut egui::Ui, setter: &ParamSetter) {
+        let band = self.params.band(self.selected_band);
+        let color = BAND_COLORS[self.selected_band];
+
+        egui::Frame::new()
+            .fill(Color32::from_rgb(35, 35, 40))
+            .corner_radius(8.0)
+            .inner_margin(15.0)
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    // Enabled toggle
+                    let mut enabled = band.enabled.value();
+                    if ui
+                        .add(egui::Checkbox::new(&mut enabled, "Enabled"))
+                        .changed()
+                    {
+                        setter.set_parameter(&band.enabled, enabled);
+                    }
+
+                    ui.separator();
+
+                    // Filter type selector
+                    ui.label("Type:");
+                    let current_type = band.filter_type.value();
+                    egui::ComboBox::from_id_salt(format!("filter_type_{}", self.selected_band))
+                        .selected_text(filter_type_name(current_type))
+                        .show_ui(ui, |ui| {
+                            for filter_type in [
+                                FilterType::Peak,
+                                FilterType::LowShelf,
+                                FilterType::HighShelf,
+                                FilterType::LowPass,
+                                FilterType::HighPass,
+                            ] {
+                                if ui
+                                    .selectable_label(
+                                        current_type == filter_type,
+                                        filter_type_name(filter_type),
+                                    )
+                                    .clicked()
+                                {
+                                    setter.set_parameter(&band.filter_type, filter_type);
+                                }
+                            }
+                        });
+                });
+
+                ui.add_space(10.0);
+
+                // Parameter knobs row
+                ui.horizontal(|ui| {
+                    // Frequency
+                    ui.vertical(|ui| {
+                        ui.label("Frequency");
+                        let mut freq = band.frequency.value();
+                        let speed = freq * 0.01; // Compute before borrowing
+                        if ui
+                            .add(
+                                egui::DragValue::new(&mut freq)
+                                    .range(20.0..=20000.0)
+                                    .speed(speed)
+                                    .custom_formatter(|v, _| {
+                                        if v >= 1000.0 {
+                                            format!("{:.1} kHz", v / 1000.0)
+                                        } else {
+                                            format!("{:.0} Hz", v)
+                                        }
+                                    }),
+                            )
+                            .changed()
+                        {
+                            setter.set_parameter(&band.frequency, freq);
+                        }
+                    });
+
+                    ui.add_space(20.0);
+
+                    // Q
+                    ui.vertical(|ui| {
+                        ui.label("Q");
+                        let mut q = band.q.value();
+                        if ui
+                            .add(
+                                egui::DragValue::new(&mut q)
+                                    .range(0.1..=10.0)
+                                    .speed(0.01)
+                                    .max_decimals(2),
+                            )
+                            .changed()
+                        {
+                            setter.set_parameter(&band.q, q);
+                        }
+                    });
+
+                    ui.add_space(20.0);
+
+                    // Gain
+                    ui.vertical(|ui| {
+                        ui.label("Gain");
+                        let mut gain = band.gain_db.value();
+                        if ui
+                            .add(
+                                egui::DragValue::new(&mut gain)
+                                    .range(-24.0..=24.0)
+                                    .speed(0.1)
+                                    .suffix(" dB")
+                                    .max_decimals(1),
+                            )
+                            .changed()
+                        {
+                            setter.set_parameter(&band.gain_db, gain);
+                        }
+                    });
+
+                    // Visual indicator
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.add_space(10.0);
+                        let (_, painter) = ui.allocate_painter(Vec2::new(20.0, 20.0), egui::Sense::hover());
+                        painter.circle_filled(
+                            painter.clip_rect().center(),
+                            8.0,
+                            color,
+                        );
+                    });
+                });
+            });
+    }
+
+    /// Convert frequency to X coordinate (logarithmic scale)
+    fn freq_to_x(&self, freq: f64, rect: Rect) -> f32 {
+        let min_freq = 20.0_f64;
+        let max_freq = 20000.0_f64;
+        let log_min = min_freq.ln();
+        let log_max = max_freq.ln();
+        let t = (freq.ln() - log_min) / (log_max - log_min);
+        rect.left() + (t as f32) * rect.width()
+    }
+
+    /// Convert gain to Y coordinate
+    fn gain_to_y(&self, gain: f64, rect: Rect) -> f32 {
+        let min_gain = -24.0;
+        let max_gain = 24.0;
+        let t = (gain - max_gain) / (min_gain - max_gain);
+        rect.top() + (t as f32) * rect.height()
+    }
+}
+
+/// Convert our FilterType to autoeq_iir's BiquadFilterType
+fn convert_filter_type(filter_type: FilterType) -> BiquadFilterType {
+    match filter_type {
+        FilterType::Peak => BiquadFilterType::Peak,
+        FilterType::LowShelf => BiquadFilterType::Lowshelf,
+        FilterType::HighShelf => BiquadFilterType::Highshelf,
+        FilterType::LowPass => BiquadFilterType::Lowpass,
+        FilterType::HighPass => BiquadFilterType::Highpass,
+    }
+}
+
+/// Get display name for filter type
+fn filter_type_name(filter_type: FilterType) -> &'static str {
+    match filter_type {
+        FilterType::Peak => "Peak",
+        FilterType::LowShelf => "Low Shelf",
+        FilterType::HighShelf => "High Shelf",
+        FilterType::LowPass => "Low Pass",
+        FilterType::HighPass => "High Pass",
+    }
+}

--- a/sotf-audio-plugins/src-vst3/src/editor/mod.rs
+++ b/sotf-audio-plugins/src-vst3/src/editor/mod.rs
@@ -1,0 +1,61 @@
+//! EQ Plugin Editor
+//!
+//! Implements the nih-plug Editor trait with egui-based visualization.
+
+mod eq_view;
+
+use crate::eq_params::SotfEqParams;
+use eq_view::EqEditorState;
+use nih_plug::prelude::*;
+use nih_plug_egui::egui;
+use nih_plug_egui::{create_egui_editor, EguiState};
+use std::sync::Arc;
+
+/// Editor window dimensions
+const EDITOR_WIDTH: u32 = 800;
+const EDITOR_HEIGHT: u32 = 500;
+
+/// Create the EQ plugin editor
+pub fn create_editor(
+    params: Arc<SotfEqParams>,
+    egui_state: Arc<EguiState>,
+) -> Option<Box<dyn Editor>> {
+    create_egui_editor(
+        egui_state,
+        EqEditorState::new(params),
+        |ctx, _| {
+            // Apply custom fonts and styling
+            setup_custom_style(ctx);
+        },
+        move |ctx, setter, state| {
+            state.ui(ctx, setter);
+        },
+    )
+}
+
+/// Create the egui state for persistence
+pub fn create_egui_state() -> Arc<EguiState> {
+    EguiState::from_size(EDITOR_WIDTH, EDITOR_HEIGHT)
+}
+
+/// Set up custom egui styling
+fn setup_custom_style(ctx: &egui::Context) {
+    let mut style = (*ctx.style()).clone();
+
+    // Use a dark theme
+    style.visuals = egui::Visuals::dark();
+
+    // Customize colors
+    style.visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(40, 40, 45);
+    style.visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(50, 50, 55);
+    style.visuals.widgets.active.bg_fill = egui::Color32::from_rgb(60, 60, 70);
+
+    // Panel background
+    style.visuals.panel_fill = egui::Color32::from_rgb(25, 25, 30);
+    style.visuals.window_fill = egui::Color32::from_rgb(30, 30, 35);
+
+    // Accent color
+    style.visuals.selection.bg_fill = egui::Color32::from_rgb(80, 120, 200);
+
+    ctx.set_style(style);
+}

--- a/sotf-audio-plugins/src-vst3/src/eq_params.rs
+++ b/sotf-audio-plugins/src-vst3/src/eq_params.rs
@@ -1,0 +1,185 @@
+//! EQ Plugin Parameters
+//!
+//! Defines all parameters for the 4-band parametric EQ using nih-plug's parameter system.
+
+use nih_plug::prelude::*;
+use std::sync::Arc;
+
+/// Number of EQ bands
+pub const NUM_BANDS: usize = 4;
+
+/// Filter types available for each band
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+pub enum FilterType {
+    #[id = "peak"]
+    #[name = "Peak"]
+    Peak,
+
+    #[id = "lowshelf"]
+    #[name = "Low Shelf"]
+    LowShelf,
+
+    #[id = "highshelf"]
+    #[name = "High Shelf"]
+    HighShelf,
+
+    #[id = "lowpass"]
+    #[name = "Low Pass"]
+    LowPass,
+
+    #[id = "highpass"]
+    #[name = "High Pass"]
+    HighPass,
+}
+
+impl Default for FilterType {
+    fn default() -> Self {
+        Self::Peak
+    }
+}
+
+/// Parameters for a single EQ band
+#[derive(Params)]
+pub struct EqBandParams {
+    /// Filter type (peak, shelf, pass, etc.)
+    #[id = "type"]
+    pub filter_type: EnumParam<FilterType>,
+
+    /// Center/corner frequency in Hz (20-20000, logarithmic)
+    #[id = "freq"]
+    pub frequency: FloatParam,
+
+    /// Q factor / bandwidth (0.1-10)
+    #[id = "q"]
+    pub q: FloatParam,
+
+    /// Gain in dB (-24 to +24)
+    #[id = "gain"]
+    pub gain_db: FloatParam,
+
+    /// Band enabled/bypassed
+    #[id = "enabled"]
+    pub enabled: BoolParam,
+}
+
+impl EqBandParams {
+    /// Create a new EQ band with default parameters for the given band index
+    pub fn new(band_index: usize) -> Self {
+        // Default frequencies for 4 bands: 100Hz, 500Hz, 2kHz, 8kHz
+        let default_freq = match band_index {
+            0 => 100.0,
+            1 => 500.0,
+            2 => 2000.0,
+            3 => 8000.0,
+            _ => 1000.0,
+        };
+
+        Self {
+            filter_type: EnumParam::new("Type", FilterType::Peak),
+
+            frequency: FloatParam::new(
+                "Frequency",
+                default_freq,
+                FloatRange::Skewed {
+                    min: 20.0,
+                    max: 20000.0,
+                    factor: FloatRange::skew_factor(-2.0), // Logarithmic
+                },
+            )
+            .with_unit(" Hz")
+            .with_value_to_string(formatters::v2s_f32_hz_then_khz(0)),
+
+            q: FloatParam::new(
+                "Q",
+                1.0,
+                FloatRange::Skewed {
+                    min: 0.1,
+                    max: 10.0,
+                    factor: FloatRange::skew_factor(-1.0),
+                },
+            )
+            .with_step_size(0.01),
+
+            gain_db: FloatParam::new(
+                "Gain",
+                0.0,
+                FloatRange::Linear {
+                    min: -24.0,
+                    max: 24.0,
+                },
+            )
+            .with_unit(" dB")
+            .with_step_size(0.1),
+
+            enabled: BoolParam::new("Enabled", true),
+        }
+    }
+}
+
+impl Default for EqBandParams {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+/// Main EQ plugin parameters
+#[derive(Params)]
+pub struct SotfEqParams {
+    /// Band 1 parameters
+    #[nested(id_prefix = "band1", group = "Band 1")]
+    pub band1: EqBandParams,
+
+    /// Band 2 parameters
+    #[nested(id_prefix = "band2", group = "Band 2")]
+    pub band2: EqBandParams,
+
+    /// Band 3 parameters
+    #[nested(id_prefix = "band3", group = "Band 3")]
+    pub band3: EqBandParams,
+
+    /// Band 4 parameters
+    #[nested(id_prefix = "band4", group = "Band 4")]
+    pub band4: EqBandParams,
+
+    /// Output gain in dB
+    #[id = "output_gain"]
+    pub output_gain: FloatParam,
+}
+
+impl SotfEqParams {
+    /// Get band parameters by index (0-3)
+    pub fn band(&self, index: usize) -> &EqBandParams {
+        match index {
+            0 => &self.band1,
+            1 => &self.band2,
+            2 => &self.band3,
+            _ => &self.band4,
+        }
+    }
+}
+
+impl Default for SotfEqParams {
+    fn default() -> Self {
+        Self {
+            band1: EqBandParams::new(0),
+            band2: EqBandParams::new(1),
+            band3: EqBandParams::new(2),
+            band4: EqBandParams::new(3),
+            output_gain: FloatParam::new(
+                "Output Gain",
+                0.0,
+                FloatRange::Linear {
+                    min: -24.0,
+                    max: 24.0,
+                },
+            )
+            .with_unit(" dB")
+            .with_step_size(0.1),
+        }
+    }
+}
+
+/// Create the plugin parameters wrapped in Arc for thread-safe sharing
+pub fn create_params() -> Arc<SotfEqParams> {
+    Arc::new(SotfEqParams::default())
+}

--- a/sotf-audio-plugins/src-vst3/src/eq_plugin.rs
+++ b/sotf-audio-plugins/src-vst3/src/eq_plugin.rs
@@ -1,0 +1,187 @@
+//! SOTF EQ Plugin Implementation
+//!
+//! A 4-band parametric equalizer using nih-plug and autoeq_iir biquad filters.
+
+use crate::editor::{create_editor, create_egui_state};
+use crate::eq_params::{FilterType, SotfEqParams, NUM_BANDS};
+use autoeq_iir::{Biquad, BiquadFilterType};
+use nih_plug::prelude::*;
+use nih_plug_egui::EguiState;
+use std::sync::Arc;
+
+/// SOTF Parametric EQ Plugin
+pub struct SotfEq {
+    /// Plugin parameters
+    params: Arc<SotfEqParams>,
+
+    /// Egui state for the editor
+    egui_state: Arc<EguiState>,
+
+    /// Biquad filters for each band and channel
+    /// Indexed as [band][channel]
+    filters: [[Biquad; 2]; NUM_BANDS],
+
+    /// Current sample rate
+    sample_rate: f32,
+}
+
+impl Default for SotfEq {
+    fn default() -> Self {
+        Self {
+            params: Arc::new(SotfEqParams::default()),
+            egui_state: create_egui_state(),
+            filters: std::array::from_fn(|_| {
+                std::array::from_fn(|_| Biquad::new(BiquadFilterType::Peak, 1000.0, 48000.0, 1.0, 0.0))
+            }),
+            sample_rate: 48000.0,
+        }
+    }
+}
+
+impl SotfEq {
+    /// Convert our FilterType enum to autoeq_iir's BiquadFilterType
+    fn convert_filter_type(filter_type: FilterType) -> BiquadFilterType {
+        match filter_type {
+            FilterType::Peak => BiquadFilterType::Peak,
+            FilterType::LowShelf => BiquadFilterType::Lowshelf,
+            FilterType::HighShelf => BiquadFilterType::Highshelf,
+            FilterType::LowPass => BiquadFilterType::Lowpass,
+            FilterType::HighPass => BiquadFilterType::Highpass,
+        }
+    }
+
+    /// Update filter coefficients for a specific band
+    fn update_filter(&mut self, band_index: usize) {
+        let band = self.params.band(band_index);
+        let filter_type = Self::convert_filter_type(band.filter_type.value());
+        let frequency = band.frequency.value() as f64;
+        let q = band.q.value() as f64;
+        let gain_db = band.gain_db.value() as f64;
+
+        for channel in 0..2 {
+            self.filters[band_index][channel] = Biquad::new(
+                filter_type,
+                frequency,
+                self.sample_rate as f64,
+                q,
+                gain_db,
+            );
+        }
+    }
+
+    /// Update all filter coefficients
+    fn update_all_filters(&mut self) {
+        for band_index in 0..NUM_BANDS {
+            self.update_filter(band_index);
+        }
+    }
+}
+
+impl Plugin for SotfEq {
+    const NAME: &'static str = "SOTF EQ";
+    const VENDOR: &'static str = "SOTF";
+    const URL: &'static str = "https://github.com/pierreaubert/sotf";
+    const EMAIL: &'static str = "pierre@spinorama.org";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+    // Support stereo audio
+    const AUDIO_IO_LAYOUTS: &'static [AudioIOLayout] = &[
+        AudioIOLayout {
+            main_input_channels: NonZeroU32::new(2),
+            main_output_channels: NonZeroU32::new(2),
+            ..AudioIOLayout::const_default()
+        },
+        AudioIOLayout {
+            main_input_channels: NonZeroU32::new(1),
+            main_output_channels: NonZeroU32::new(1),
+            ..AudioIOLayout::const_default()
+        },
+    ];
+
+    const MIDI_INPUT: MidiConfig = MidiConfig::None;
+    const MIDI_OUTPUT: MidiConfig = MidiConfig::None;
+
+    type SysExMessage = ();
+    type BackgroundTask = ();
+
+    fn params(&self) -> Arc<dyn Params> {
+        self.params.clone()
+    }
+
+    fn editor(&mut self, _async_executor: AsyncExecutor<Self>) -> Option<Box<dyn Editor>> {
+        create_editor(self.params.clone(), self.egui_state.clone())
+    }
+
+    fn initialize(
+        &mut self,
+        _audio_io_layout: &AudioIOLayout,
+        buffer_config: &BufferConfig,
+        _context: &mut impl InitContext<Self>,
+    ) -> bool {
+        self.sample_rate = buffer_config.sample_rate;
+        self.update_all_filters();
+        true
+    }
+
+    fn reset(&mut self) {
+        // Reset filter state by recreating them
+        self.update_all_filters();
+    }
+
+    fn process(
+        &mut self,
+        buffer: &mut Buffer,
+        _aux: &mut AuxiliaryBuffers,
+        _context: &mut impl ProcessContext<Self>,
+    ) -> ProcessStatus {
+        // Check if any parameters changed and update filters
+        // In a more optimized version, we'd track parameter changes
+        self.update_all_filters();
+
+        // Get output gain as linear amplitude
+        let output_gain = util::db_to_gain(self.params.output_gain.value());
+
+        // Process each sample
+        for channel_samples in buffer.iter_samples() {
+            let num_channels = channel_samples.len().min(2);
+
+            for (channel_idx, sample) in channel_samples.into_iter().take(num_channels).enumerate()
+            {
+                let mut value = *sample as f64;
+
+                // Apply each enabled band's filter
+                for band_index in 0..NUM_BANDS {
+                    let band = self.params.band(band_index);
+                    if band.enabled.value() {
+                        value = self.filters[band_index][channel_idx].process(value);
+                    }
+                }
+
+                // Apply output gain
+                *sample = (value as f32) * output_gain;
+            }
+        }
+
+        ProcessStatus::Normal
+    }
+}
+
+impl ClapPlugin for SotfEq {
+    const CLAP_ID: &'static str = "org.spinorama.sotf-eq";
+    const CLAP_DESCRIPTION: Option<&'static str> =
+        Some("4-band parametric equalizer with graphical visualization");
+    const CLAP_MANUAL_URL: Option<&'static str> = Some(Self::URL);
+    const CLAP_SUPPORT_URL: Option<&'static str> = None;
+    const CLAP_FEATURES: &'static [ClapFeature] = &[
+        ClapFeature::AudioEffect,
+        ClapFeature::Stereo,
+        ClapFeature::Mono,
+        ClapFeature::Equalizer,
+    ];
+}
+
+impl Vst3Plugin for SotfEq {
+    const VST3_CLASS_ID: [u8; 16] = *b"SOTFEq4BandV001\0";
+    const VST3_SUBCATEGORIES: &'static [Vst3SubCategory] =
+        &[Vst3SubCategory::Fx, Vst3SubCategory::Eq];
+}

--- a/sotf-audio-plugins/src-vst3/src/lib.rs
+++ b/sotf-audio-plugins/src-vst3/src/lib.rs
@@ -1,0 +1,27 @@
+//! SOTF Audio Plugins - VST3/CLAP Wrapper
+//!
+//! This crate provides VST3 and CLAP plugin exports for SOTF audio plugins
+//! using the nih-plug framework.
+//!
+//! ## Supported Plugins
+//!
+//! - **SOTF EQ**: 4-band parametric equalizer with GPUI-based visualization
+//!
+//! ## Platform Support
+//!
+//! - Linux: VST3 + CLAP
+//! - Windows: VST3
+//! - macOS: VST3
+
+mod eq_params;
+mod eq_plugin;
+mod editor;
+
+use eq_plugin::SotfEq;
+use nih_plug::prelude::*;
+
+// Export VST3 plugin
+nih_export_vst3!(SotfEq);
+
+// Export CLAP plugin
+nih_export_clap!(SotfEq);

--- a/sotf-audio-plugins/src/plugin_convolution.rs
+++ b/sotf-audio-plugins/src/plugin_convolution.rs
@@ -1,6 +1,6 @@
-// ============================================================================
-// Convolution Plugin - FFT-based convolution for reverb and IR processing
-// ============================================================================
+//! ============================================================================
+//! Convolution Plugin - FFT-based convolution for reverb and IR processing
+//! ============================================================================
 
 use super::param_specs::convolution::*;
 use super::parameters::{Parameter, ParameterId, ParameterImportance, ParameterValue};
@@ -18,9 +18,9 @@ use symphonia::core::conv::FromSample;
 use symphonia::core::formats::{FormatOptions, FormatReader};
 use symphonia::core::io::MediaSourceStream;
 
-// ============================================================================
-// Configuration
-// ============================================================================
+/// ============================================================================
+/// Configuration
+/// ============================================================================
 
 fn default_ir_file() -> String {
     String::new()
@@ -45,9 +45,9 @@ pub struct ConvolutionPluginParams {
     pub gain_db: f32,
 }
 
-// ============================================================================
-// Plugin Implementation
-// ============================================================================
+/// ============================================================================
+/// Plugin Implementation
+/// ============================================================================
 
 struct ConvolutionState {
     ir_fft: Vec<Vec<Complex<f32>>>, // [channel][bin]

--- a/sotf-audio-plugins/src/plugin_xtc/mod.rs
+++ b/sotf-audio-plugins/src/plugin_xtc/mod.rs
@@ -1,4 +1,30 @@
-// ============================================================================ // Crosstalk Cancellation (XTC) Plugin // ============================================================================ // // Implements crosstalk cancellation for stereo playback over speakers. // This plugin removes acoustic crosstalk to create a binaural-like experience // from conventional stereo speakers. // // Algorithm: // 1. Signal Windowing & FFT: Convert to frequency domain (1024 samples, 75% overlap, Hann window) // 2. Transfer Functions: Model ipsilateral (direct) and contralateral (crosstalk) paths // 3. Inverse with smoothing: Compute regularized inverse filter matrix // 4. Apply Filter: Process stereo signal with crosstalk cancellation // 5. IFFT & Overlap-Add: Reconstruct time-domain signal // // Geometry: // - d: Distance to speakers (m) // - θ: Speaker angle (degrees, typically 30°) // - a: Head radius (m, typically 0.0875m) // // Physical Model: // - l_ipsi: Same-side path length // - l_contra: Opposite-side path length // - Δt: Time difference between paths // - g(f): Head shadowing filter (low-pass)
+//! ============================================================================
+//! Crosstalk Cancellation (XTC) Plugin
+//! ============================================================================
+//!
+//! Implements crosstalk cancellation for stereo playback over speakers.
+//! This plugin removes acoustic crosstalk to create a binaural-like experience
+//! from conventional stereo speakers.
+//!
+//! Algorithm:
+//! 1. Signal Windowing & FFT: Convert to frequency domain (1024 samples, 75% overlap, Hann window)
+//! 2. Transfer Functions: Model ipsilateral (direct) and contralateral (crosstalk) paths
+//! 3. Inverse with smoothing: Compute regularized inverse filter matrix
+//! 4. Apply Filter: Process stereo signal with crosstalk cancellation
+//! 5. IFFT & Overlap-Add: Reconstruct time-domain signal
+//!
+//! Geometry:
+//! - d: Distance to speakers (m)
+//! - θ: Speaker angle (degrees, typically 30°)
+//! - a: Head radius (m, typically 0.0875m)
+//!
+//! Physical Model:
+//! - l_ipsi: Same-side path length
+//! - l_contra: Opposite-side path length
+//! - Δt: Time difference between paths
+//! - g(f): Head shadowing filter (low-pass)
+
+
 use super::parameters::{Parameter, ParameterId, ParameterImportance, ParameterValue};
 use super::plugin::{Plugin, PluginInfo, PluginResult, ProcessContext};
 use super::simd::{
@@ -12,7 +38,9 @@ use serde::{Deserialize, Serialize};
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-// ============================================================================ // Configuration // ============================================================================
+/// ============================================================================
+/// Configuration
+/// ============================================================================
 
 /// XTC plugin configuration parameters
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,7 +153,9 @@ impl Default for XtcPluginParams {
     }
 }
 
-// ============================================================================ // Plugin Implementation // ============================================================================
+/// ============================================================================
+/// Plugin Implementation
+/// ============================================================================
 
 /// Crosstalk cancellation filters in frequency domain
 struct XtcFilters {
@@ -135,7 +165,7 @@ struct XtcFilters {
     filter_lr: Vec<Complex<f32>>,
 }
 
-/// BACCH-style Crosstalk Cancellation plugin
+/// Crosstalk Cancellation plugin
 ///
 /// Optimized with:
 /// - Block-based I/O processing (no sample-by-sample loops)
@@ -683,7 +713,9 @@ impl Plugin for XtcPlugin {
     }
 }
 
-// ============================================================================ // Crosstalk Cancellation Filter Computation // ============================================================================
+/// ============================================================================
+/// Crosstalk Cancellation Filter Computation
+/// ============================================================================
 
 /// Compute crosstalk cancellation filters in frequency domain (symmetric version)
 ///
@@ -929,7 +961,9 @@ fn compute_beta(freq: f32, params: &XtcPluginParams) -> f32 {
     beta_base * low_freq_factor * high_freq_factor
 }
 
-// ============================================================================ // Tests // ============================================================================
+/// ============================================================================
+/// Tests
+/// ============================================================================
 
 #[cfg(test)]
 mod tests {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+nih_plug_xtask = { git = "https://github.com/robbert-vdh/nih-plug.git" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,5 @@
+//! xtask for bundling VST3/CLAP plugins using nih-plug's bundler
+
+fn main() -> nih_plug_xtask::Result<()> {
+    nih_plug_xtask::main()
+}


### PR DESCRIPTION
Implement a 4-band parametric EQ plugin using nih-plug framework:

- VST3 and CLAP plugin formats for Linux (CLAP+VST3), Windows (VST3), macOS (VST3)
- egui-based graphical editor with frequency response visualization
- Individual band curves with color coding and combined response
- Filter types: Peak, Low Shelf, High Shelf, Low Pass, High Pass
- Parameters: Frequency (20Hz-20kHz), Q (0.1-10), Gain (-24 to +24 dB)
- Output gain control
- Uses autoeq-iir Biquad filters for audio processing

New files:
- sotf-audio-plugins/src-vst3/ - VST3/CLAP plugin implementation
- xtask/ - nih-plug bundler for creating plugin bundles

Build commands:
- just build-vst3 - Build plugins for current platform
- just install-vst3 - Install to system plugin directories
- just validate-vst3 - Validate with pluginval

🤖 Generated with [Claude Code](https://claude.ai/claude-code)