### PR TITLE
Fix dropdown handlers to properly trigger re-renders with cx.notify()

### DIFF
--- a/GPUI.md
+++ b/GPUI.md
@@ -1,0 +1,185 @@
+# GPUI Development Guide
+
+This guide covers patterns and best practices for developing GPUI-based UI components in the SOTF project.
+
+## Form Components Guide
+
+This section documents the patterns required to get form components (inputs, dropdowns, selects) working correctly with both mouse and keyboard interactions.
+
+### Key Principle: Every Dropdown Needs TWO Handlers
+
+For dropdown/select components to work properly, you MUST provide BOTH:
+1. `on_*_change` - Handles value selection
+2. `on_*_toggle` - Handles open/close state
+
+**CRITICAL**: The toggle handler MUST call `cx.notify()` to trigger re-render.
+
+### Correct Pattern (from spinorama_eq)
+
+```rust
+.on_algo_change({
+    let state = self.state.clone();
+    move |algo, _window, cx| {
+        state.update(cx, |state, _cx| {
+            // Update the value
+            state.app.some_state.config.algorithm = parse_algo(algo);
+            // Close the dropdown after selection
+            state.app.some_state.dropdowns.algorithm_open = false;
+        });
+    }
+})
+.on_algo_toggle({
+    let state = self.state.clone();
+    move |open, _window, cx| {
+        state.update(cx, |state, cx| {  // NOTE: Use cx, not _cx
+            // Update the open state
+            state.app.some_state.dropdowns.algorithm_open = open;
+            // CRITICAL: Must call cx.notify() to trigger re-render
+            cx.notify();
+        });
+    }
+})
+```
+
+### Incorrect Pattern (causes dropdowns to not respond)
+
+```rust
+// WRONG - Missing cx.notify() in toggle handler
+.on_algo_toggle({
+    let state = self.state.clone();
+    move |open, _window, cx| {
+        state.update(cx, |state, _cx| {  // _cx is unused - BAD SIGN
+            state.app.some_state.dropdowns.algorithm_open = open;
+            // Missing cx.notify() - dropdown won't update!
+        });
+    }
+})
+```
+
+### NumberInput Component
+
+NumberInput components work differently - they manage their own editing state via thread-local storage. The key pattern:
+
+```rust
+NumberInput::new("unique-id")
+    .value(current_value)
+    .min(0.0)
+    .max(100.0)
+    .step(1.0)
+    .on_change({
+        let state = self.state.clone();
+        move |new_value, _window, cx| {
+            state.update(cx, |state, _cx| {
+                state.app.some_state.config.value = new_value;
+            });
+        }
+    })
+```
+
+NumberInput supports:
+- Click to start editing
+- Double-click to select all
+- Enter to confirm
+- Escape to cancel
+- Arrow Up/Down to increment/decrement
+
+### State Structure for Dropdowns
+
+Each component using dropdowns needs a separate state struct for tracking open states:
+
+```rust
+#[derive(Clone, Default)]
+pub struct MyDropdownStates {
+    pub algorithm_open: bool,
+    pub peq_model_open: bool,
+    pub strategy_open: bool,
+    // ... one field per dropdown
+}
+```
+
+### Preventing Global Shortcuts During Input
+
+Wrap form components in a div that stops key event propagation:
+
+```rust
+.child(
+    div()
+        .on_key_down(|_event, _window, cx| {
+            cx.stop_propagation();
+        })
+        .child(autoeq_form),
+)
+```
+
+### AutoEqForm Complete Handler List
+
+When using `AutoEqForm`, these are all the handlers you may need to wire up:
+
+**Dropdowns (need both `_change` and `_toggle`):**
+- `on_opt_mode_change` / `on_opt_mode_toggle`
+- `on_peq_model_change` / `on_peq_model_toggle`
+- `on_algo_change` / `on_algo_toggle`
+- `on_strategy_change` / `on_strategy_toggle`
+- `on_local_algo_change` / `on_local_algo_toggle`
+- `on_fir_phase_change` / `on_fir_phase_toggle`
+- `on_loss_type_change` / `on_loss_type_toggle`
+- `on_target_curve_change` / `on_target_curve_toggle`
+- `on_system_type_change` / `on_system_type_toggle`
+
+**NumberInputs (only need `_change`):**
+- `on_num_filters_change`
+- `on_min_q_change` / `on_max_q_change`
+- `on_min_db_change` / `on_max_db_change`
+- `on_min_freq_change` / `on_max_freq_change`
+- `on_maxeval_change`
+- `on_population_change`
+- `on_de_f_change` / `on_de_cr_change`
+- `on_tolerance_change` / `on_atolerance_change`
+- `on_smooth_change` / `on_smooth_n_change`
+- `on_spacing_weight_change`
+- `on_min_spacing_oct_change`
+- `on_sample_rate_change`
+- `on_fir_taps_change`
+- `on_refine_change` (boolean toggle)
+
+### Plugin UI Components (Potentiometer, Slider)
+
+For plugin UIs using `Potentiometer` or `VerticalSlider`:
+
+```rust
+fn render_knob(
+    label: &str,
+    value: f64,
+    min: f64,
+    max: f64,
+    entity: &Entity<AppState>,
+    plugin_idx: usize,
+    param_idx: usize,
+) -> impl IntoElement {
+    Potentiometer::new(format!("knob-{}-{}", plugin_idx, param_idx))
+        .value(normalize(value, min, max))
+        .on_change({
+            let entity = entity.clone();
+            move |new_value, _, cx| {
+                entity.update(cx, |state, _| {
+                    let denorm = denormalize(new_value, min, max);
+                    state.app.set_plugin_param(plugin_idx, param_idx, denorm);
+                });
+            }
+        })
+}
+```
+
+### Debugging Form Issues
+
+If a form element isn't responding:
+
+1. **Dropdown won't open**: Check if `on_*_toggle` handler exists and calls `cx.notify()`
+2. **Dropdown won't close after selection**: Check if `on_*_change` sets the `*_open` flag to `false`
+3. **Input not editable**: Check if the form is wrapped in a div with `on_key_down` that stops propagation
+4. **Value not updating**: Check if `on_change` handler updates the correct state field
+5. **UI not reflecting changes**: Ensure `cx.notify()` is called in the appropriate handler
+
+### Reference Implementation
+
+See `crates/app-gpui/components/spinorama_eq/step_2_configure.rs` as the canonical reference for a fully working form implementation with all handlers properly wired.

--- a/crates/app-gpui/components/headphone_eq/step_2_optimisation.rs
+++ b/crates/app-gpui/components/headphone_eq/step_2_optimisation.rs
@@ -92,13 +92,14 @@ impl PlayerView {
             .on_loss_type_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .loss_type_open = open;
+                        cx.notify();
                     });
                 }
             })
@@ -120,13 +121,14 @@ impl PlayerView {
             .on_target_curve_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .target_curve_open = open;
+                        cx.notify();
                     });
                 }
             })
@@ -158,13 +160,14 @@ impl PlayerView {
             .on_algo_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .algorithm_open = open;
+                        cx.notify();
                     });
                 }
             })
@@ -190,13 +193,14 @@ impl PlayerView {
             .on_peq_model_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .peq_model_open = open;
+                        cx.notify();
                     });
                 }
             })
@@ -261,13 +265,14 @@ impl PlayerView {
             .on_strategy_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .strategy_open = open;
+                        cx.notify();
                     });
                 }
             })
@@ -319,13 +324,14 @@ impl PlayerView {
             .on_local_algo_toggle({
                 let state = self.state.clone();
                 move |open, _window, cx| {
-                    state.update(cx, |state, _cx| {
+                    state.update(cx, |state, cx| {
                         state
                             .app
                             .measurement_state
                             .headphone_eq_state
                             .dropdowns
                             .local_algo_open = open;
+                        cx.notify();
                     });
                 }
             })

--- a/crates/app-gpui/components/plugins/ui_ab_compare.rs
+++ b/crates/app-gpui/components/plugins/ui_ab_compare.rs
@@ -513,12 +513,13 @@ fn render_path_selector(
         .on_toggle({
             let entity = entity.clone();
             move |open, _, cx| {
-                entity.update(cx, |state, _| {
+                entity.update(cx, |state, cx| {
                     if is_path_a {
                         state.app.plugin_state.ab_compare_dropdowns.path_a_open = open;
                     } else {
                         state.app.plugin_state.ab_compare_dropdowns.path_b_open = open;
                     }
+                    cx.notify();
                 });
             }
         })

--- a/crates/app-gpui/components/plugins/ui_spectrum.rs
+++ b/crates/app-gpui/components/plugins/ui_spectrum.rs
@@ -703,8 +703,9 @@ pub fn render_spectrum_analyzer_plugin(
                                     .on_toggle({
                                         let entity = entity.clone();
                                         move |is_open, _window, cx| {
-                                            entity.update(cx, |state, _| {
+                                            entity.update(cx, |state, cx| {
                                                 state.app.spectrum_tilt_select_open = is_open;
+                                                cx.notify();
                                             });
                                         }
                                     })
@@ -756,8 +757,9 @@ pub fn render_spectrum_analyzer_plugin(
                                     .on_toggle({
                                         let entity = entity.clone();
                                         move |is_open, _window, cx| {
-                                            entity.update(cx, |state, _| {
+                                            entity.update(cx, |state, cx| {
                                                 state.app.spectrum_reference_select_open = is_open;
+                                                cx.notify();
                                             });
                                         }
                                     })

--- a/crates/app-gpui/components/plugins/ui_upmixer.rs
+++ b/crates/app-gpui/components/plugins/ui_upmixer.rs
@@ -157,8 +157,9 @@ pub fn render_upmixer_plugin(
                                 .on_toggle({
                                     let entity = entity.clone();
                                     move |is_open, _window, cx| {
-                                        entity.update(cx, |state, _| {
+                                        entity.update(cx, |state, cx| {
                                             state.app.upmixer_config_open = is_open;
+                                            cx.notify();
                                         });
                                     }
                                 })


### PR DESCRIPTION
## Summary
Fixed a critical bug in dropdown/select component handlers across multiple UI components where toggle handlers were not calling `cx.notify()`, preventing proper re-renders when opening/closing dropdowns.

## Key Changes
- **Added `cx.notify()` calls** to all `on_*_toggle` handlers in dropdown components to ensure UI updates when open/close state changes
- **Fixed parameter naming** in toggle handlers from `_cx` to `cx` to properly access the context for notification
- **Added GPUI Development Guide** (`GPUI.md`) documenting the critical pattern that every dropdown needs both `on_*_change` and `on_*_toggle` handlers, with the toggle handler calling `cx.notify()`

## Files Modified
- `crates/app-gpui/components/headphone_eq/step_2_optimisation.rs` - Fixed 5 dropdown toggle handlers
- `crates/app-gpui/components/plugins/ui_ab_compare.rs` - Fixed path selector toggle handler
- `crates/app-gpui/components/plugins/ui_spectrum.rs` - Fixed 2 spectrum analyzer dropdown toggle handlers
- `crates/app-gpui/components/plugins/ui_upmixer.rs` - Fixed upmixer config dropdown toggle handler

## Implementation Details
The root cause was that toggle handlers were using `_cx` (unused parameter) instead of `cx`, and critically, were not calling `cx.notify()` to trigger a re-render. This caused dropdowns to not visually update their open/close state even though the underlying state was being updated.

The correct pattern now enforced:
```rust
.on_*_toggle({
    let state = self.state.clone();
    move |open, _window, cx| {
        state.update(cx, |state, cx| {  // Use cx, not _cx
            state.app.some_state.dropdowns.*_open = open;
            cx.notify();  // CRITICAL: Trigger re-render
        });
    }
})
```

The new GPUI.md guide serves as a reference for developers to understand this pattern and avoid similar issues in the future.

https://claude.ai/code/session_01FHik54WCNXLCwELofaj7BJ