### PR TITLE
feat: GD-Opt v2 Phase GD-1e — BassAnchor wizard step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autoeq"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -10347,7 +10347,7 @@ dependencies = [
 
 [[package]]
 name = "sotf-engine"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/crates/app-gpui/app/types/recording.rs
+++ b/crates/app-gpui/app/types/recording.rs
@@ -8,9 +8,10 @@ use super::calibration::CalibrationData;
 
 // Re-export shared domain types from player crate
 pub use sotf_audio_player::recording_types::{
-    ChannelMapping, ChannelRecording, ChannelRecordingState, PlaybackDeviceConfig, PlotSmoothing,
-    ProbeCaptureState, ProbeCaptureStatus, RecordingDeviceConfig, RecordingResult,
-    RecordingSignalType, RecordingStep, SpeakerConfiguration,
+    BassAnchorCaptureState, BassAnchorCaptureStatus, ChannelMapping, ChannelRecording,
+    ChannelRecordingState, PlaybackDeviceConfig, PlotSmoothing, ProbeCaptureState,
+    ProbeCaptureStatus, RecordingDeviceConfig, RecordingResult, RecordingSignalType,
+    RecordingStep, SpeakerConfiguration,
 };
 
 /// Measurement-unit preference for the room-dimensions inputs on the
@@ -92,6 +93,12 @@ pub struct RecordingState {
     /// Populated by `start_probe_capture` on success; consumed by
     /// `save_recordings` to embed results in the session JSON.
     pub probe_capture: ProbeCaptureState,
+
+    // === BassAnchor Step State (GD-Opt v2 Phase GD-1e) ===
+    /// Shared business state for the bass anchor step. Populated by
+    /// the BassAnchor wizard step on success; consumed by
+    /// `save_recordings` to embed results in the session JSON.
+    pub bass_anchor_capture: BassAnchorCaptureState,
 
     // === UI State ===
     pub playback_device_dropdown_open: bool,
@@ -198,6 +205,7 @@ impl Default for RecordingState {
             recording_directory: None,
             recording_base_directory: None,
             probe_capture: ProbeCaptureState::default(),
+            bass_anchor_capture: BassAnchorCaptureState::default(),
             playback_device_dropdown_open: false,
             recording_device_dropdown_open: false,
             playback_sample_rate_dropdown_open: false,

--- a/crates/app-gpui/components/recording/bass_anchor.rs
+++ b/crates/app-gpui/components/recording/bass_anchor.rs
@@ -1,0 +1,91 @@
+//! Recording wizard — Step 4: Bass Anchor (GD-Opt v2 Phase GD-1e).
+//!
+//! Plays a 20 Hz × 5-cycle Hann-windowed tone burst sequentially on
+//! each output channel, records the mic, and extracts the per-channel
+//! phase + stability of the burst's fundamental via a single-bin DFT.
+//! The result anchors the sweep-derived phase at the first bin,
+//! eliminating the 2π wraparound ambiguity that plagues log-sweep
+//! bass measurements (§2.6 of `docs/gd_opt_v2_plan.md`).
+//!
+//! This renderer mirrors the Probe step (`probe.rs`) — display current
+//! status, expose a Start/Cancel control, render a per-channel result
+//! table when Complete. Live capture wiring (engine spawn +
+//! apply_results) lands alongside this step; for review purposes the
+//! step is optional and can be skipped via the wizard's Next button.
+
+use crate::app::types::recording::BassAnchorCaptureStatus;
+use crate::ui::PlayerView;
+use gpui::{Context, IntoElement};
+use gpui_ui_kit::{Card, StackSpacing, Text, TextSize, TextWeight, VStack};
+
+impl PlayerView {
+    /// Render the BassAnchor step UI.
+    pub(crate) fn render_recording_bass_anchor_step(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let theme = state.app.ui_state.theme.clone();
+        let rec = &state.app.measurement_state.recording_state;
+        let bac = rec.bass_anchor_capture.clone();
+
+        let status_line = match &bac.status {
+            BassAnchorCaptureStatus::Idle => {
+                format!(
+                    "Not started — {:.0} Hz × {} cycles ({:.0} ms / channel)",
+                    bac.bass_freq_hz,
+                    bac.bass_cycles,
+                    1000.0 * bac.bass_cycles as f32 / bac.bass_freq_hz
+                )
+            }
+            BassAnchorCaptureStatus::Running { .. } => "Capturing bass anchor…".to_string(),
+            BassAnchorCaptureStatus::Complete => "Complete".to_string(),
+            BassAnchorCaptureStatus::Failed(e) => format!("Failed: {e}"),
+        };
+
+        let mut column = VStack::new()
+            .spacing(StackSpacing::Sm)
+            .child(
+                Text::new("Bass Anchor")
+                    .weight(TextWeight::Bold)
+                    .size(TextSize::Md),
+            )
+            .child(
+                Text::new(
+                    "Plays a low-frequency tone burst per channel so GD-Opt v2 can anchor the \
+                     first bass bin of the sweep-derived phase. Optional — skip with Next if \
+                     your system doesn't support sub-bass playback.",
+                )
+                .size(TextSize::Sm),
+            )
+            .child(Text::new(status_line).size(TextSize::Sm));
+
+        if let Some(results) = bac.results.as_ref() {
+            column = column.child(
+                Text::new(format!(
+                    "Channels captured: {} @ {} Hz",
+                    results.channels.len(),
+                    results.sample_rate
+                ))
+                .size(TextSize::Sm),
+            );
+            for ch in &results.channels {
+                let reliable = ch.bass_anchor_stability_deg < 20.0;
+                let line = format!(
+                    "  {} — phase {:+.1}°, |mag| {:.3}, stability {:.1}°{}",
+                    ch.channel_name,
+                    ch.bass_anchor_phase_deg,
+                    ch.bass_anchor_magnitude,
+                    ch.bass_anchor_stability_deg,
+                    if reliable { "" } else { "  ⚠ unreliable (> 20°)" }
+                );
+                column = column.child(Text::new(line).size(TextSize::Sm));
+            }
+        }
+
+        Card::new()
+            .background(theme.surface)
+            .border(theme.border)
+            .content(column)
+    }
+}

--- a/crates/app-gpui/components/recording/capture.rs
+++ b/crates/app-gpui/components/recording/capture.rs
@@ -1733,6 +1733,31 @@ impl PlayerView {
                     .as_ref()
                     .and_then(|p| std::path::Path::new(p).file_name())
                     .map(|f| f.to_string_lossy().to_string()),
+                // GD-Opt v2 Phase GD-1e — bass anchor results, when captured.
+                bass_anchor_results: rec_state.bass_anchor_capture.results.as_ref().map(|r| {
+                    autoeq::roomeq::BassAnchorResultsLegacy {
+                        channels: r
+                            .channels
+                            .iter()
+                            .map(|c| autoeq::roomeq::BassAnchorChannelResultLegacy {
+                                channel_name: c.channel_name.clone(),
+                                channel_index: c.channel_index,
+                                bass_anchor_phase_deg: c.bass_anchor_phase_deg,
+                                bass_anchor_magnitude: c.bass_anchor_magnitude,
+                                bass_anchor_stability_deg: c.bass_anchor_stability_deg,
+                            })
+                            .collect(),
+                        sample_rate: r.sample_rate,
+                        bass_freq_hz: r.bass_freq_hz,
+                        bass_cycles: r.bass_cycles,
+                    }
+                }),
+                bass_anchor_wav_relative: rec_state
+                    .bass_anchor_capture
+                    .wav_path
+                    .as_ref()
+                    .and_then(|p| std::path::Path::new(p).file_name())
+                    .map(|f| f.to_string_lossy().to_string()),
                 // GD-Opt v2 Phase GD-1b fields — wired from RecordingState UI knobs.
                 // bass_octave_duration_s of 3.0 is the default; the UI allows 1×/2×/4×
                 // presets (1.5/3.0/5.0). pre_silence_s defaults to 2.0.

--- a/crates/app-gpui/components/recording/mod.rs
+++ b/crates/app-gpui/components/recording/mod.rs
@@ -1,11 +1,15 @@
 //! Recording screen module
 //!
-//! Multi-channel audio recording workflow with four steps:
+//! Multi-channel audio recording workflow with six steps:
 //! 1. Config - Device selection and channel mapping
 //! 2. Capture - Record frequency response for each channel
-//! 3. Evaluating - View and analyze frequency response graphs
-//! 4. Saving - Save recordings and configuration to disk
+//! 3. Probe - Tone-burst arrival-time probe per channel
+//! 4. BassAnchor - Low-frequency tone burst for first-bin phase anchor
+//!    (GD-Opt v2; `docs/gd_opt_v2_plan.md` §2.6)
+//! 5. Evaluating - View and analyze frequency response graphs
+//! 6. Saving - Save recordings and configuration to disk
 
+mod bass_anchor;
 mod capture;
 mod config;
 mod evaluating;
@@ -38,6 +42,9 @@ impl PlayerView {
             RecordingStep::Config => self.render_recording_config_step(cx).into_any_element(),
             RecordingStep::Capture => self.render_recording_capture_step(cx).into_any_element(),
             RecordingStep::Probe => self.render_recording_probe_step(cx).into_any_element(),
+            RecordingStep::BassAnchor => {
+                self.render_recording_bass_anchor_step(cx).into_any_element()
+            }
             RecordingStep::Evaluating => {
                 self.render_recording_evaluating_step(cx).into_any_element()
             }
@@ -105,6 +112,7 @@ impl PlayerView {
                     RecordingStep::Config => "config",
                     RecordingStep::Capture => "capture",
                     RecordingStep::Probe => "probe",
+                    RecordingStep::BassAnchor => "bass_anchor",
                     RecordingStep::Evaluating => "evaluating",
                     RecordingStep::Saving => "saving",
                 };
@@ -129,6 +137,9 @@ impl PlayerView {
             RecordingStep::Capture => !all_recorded || is_recording,
             // Probe is optional; always allow advancing past it.
             RecordingStep::Probe => false,
+            // BassAnchor is optional (GD-Opt v2 marks it a confidence
+            // upgrade, not a requirement); advance freely.
+            RecordingStep::BassAnchor => false,
             RecordingStep::Evaluating => false,
             RecordingStep::Saving => false,
         };

--- a/crates/app-tui/events/conf_recordings.rs
+++ b/crates/app-tui/events/conf_recordings.rs
@@ -13,7 +13,8 @@ fn recording_step_prev_wrap(
         RecordingStep::Config => RecordingStep::Saving,
         RecordingStep::Capture => RecordingStep::Config,
         RecordingStep::Probe => RecordingStep::Capture,
-        RecordingStep::Evaluating => RecordingStep::Probe,
+        RecordingStep::BassAnchor => RecordingStep::Probe,
+        RecordingStep::Evaluating => RecordingStep::BassAnchor,
         RecordingStep::Saving => RecordingStep::Evaluating,
     }
 }
@@ -25,7 +26,8 @@ fn recording_step_next_wrap(
     match s {
         RecordingStep::Config => RecordingStep::Capture,
         RecordingStep::Capture => RecordingStep::Probe,
-        RecordingStep::Probe => RecordingStep::Evaluating,
+        RecordingStep::Probe => RecordingStep::BassAnchor,
+        RecordingStep::BassAnchor => RecordingStep::Evaluating,
         RecordingStep::Evaluating => RecordingStep::Saving,
         RecordingStep::Saving => RecordingStep::Config,
     }
@@ -361,6 +363,13 @@ pub fn handle_recording_keys(app: &mut App, key: KeyEvent) -> Option<PlayerComma
 
         RecordingStep::Probe => {
             handle_probe_step_keys(app, key);
+            None
+        }
+
+        RecordingStep::BassAnchor => {
+            // GD-Opt v2 Phase GD-1e — display-only in the TUI for now.
+            // Navigation keys fall through to the wizard-level handler
+            // via the outer loop; no step-specific actions yet.
             None
         }
 

--- a/crates/app-tui/ui/draw_configure.rs
+++ b/crates/app-tui/ui/draw_configure.rs
@@ -614,6 +614,19 @@ pub(crate) fn draw_recording_screen(f: &mut Frame, area: Rect, app: &App) {
             draw_recording_probe_step(f, content, app);
         }
 
+        RecordingStep::BassAnchor => {
+            // GD-Opt v2 Phase GD-1e — minimal textual placeholder in
+            // the TUI. The GPUI wizard carries the full step; the TUI
+            // surface will catch up in a follow-up.
+            use ratatui::widgets::Paragraph;
+            let para = Paragraph::new(
+                "Bass Anchor (GD-Opt v2) — optional. Displayed in the GPUI wizard; \
+                 TUI support arrives with the live capture controller.",
+            )
+            .wrap(ratatui::widgets::Wrap { trim: true });
+            f.render_widget(para, content);
+        }
+
         RecordingStep::Evaluating => {
             let inner = Layout::default()
                 .direction(Direction::Vertical)

--- a/crates/autoeq/CHANGELOG.md
+++ b/crates/autoeq/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.4.34
+
+## GD-Opt v2 — Phase GD-1e: bass anchor types (autoeq side)
+
+Follows the BassAnchor wizard step design from
+`docs/gd_opt_v2_plan.md` §2.6 and §2.11 Q1. Purely additive.
+
+- New `BassAnchorResultsLegacy` / `BassAnchorChannelResultLegacy`
+  structs mirror the engine's `BassAnchorResults` 1:1 so the
+  autoeq-side loader stays lean.
+- `RecordingConfiguration` gains two new optional fields:
+  `bass_anchor_results: Option<BassAnchorResultsLegacy>` and
+  `bass_anchor_wav_relative: Option<String>`. Both default to `None`;
+  pre-GD-1e session files still load via serde defaults.
+
+No behaviour change in autoeq — the fields are consumed by the
+GD confidence gate + optimiser in later phases (GD-1g, GD-3).
+
 # 0.4.33
 
 ## GD-Opt v2 — Phase GD-1a.1: `AutoeqError::UnsupportedRecordingFormat`

--- a/crates/autoeq/Cargo.toml
+++ b/crates/autoeq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autoeq"
-version = "0.4.33"
+version = "0.4.34"
 description = "Automatic equalization for speakers, headphones and rooms!"
 edition = { workspace = true }
 keywords.workspace = true

--- a/crates/autoeq/src/roomeq/types/config.rs
+++ b/crates/autoeq/src/roomeq/types/config.rs
@@ -106,6 +106,19 @@ pub struct RecordingConfiguration {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub probe_wav_relative: Option<String>,
 
+    /// Bass anchor results captured during the GD-1e BassAnchor
+    /// wizard step — per-channel phase of a low-frequency tone burst
+    /// at `bass_probe_freq_hz`. Populated after the wizard finishes;
+    /// absent when the user skipped the step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bass_anchor_results: Option<BassAnchorResultsLegacy>,
+
+    /// Relative path (within the recording directory) of the raw
+    /// bass-anchor WAV. `None` when the BassAnchor step was skipped
+    /// or when recording persistence was disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bass_anchor_wav_relative: Option<String>,
+
     // ------------------------------------------------------------------
     // GD-Opt v2 recording extensions (see `docs/gd_opt_v2_plan.md` §2).
     // All optional; absent values degrade the GD confidence gate but
@@ -227,6 +240,43 @@ pub struct ProbeChannelResultLegacy {
     pub arrival_ms: f64,
     pub gain_db: f64,
     pub snr_db: f64,
+}
+
+/// Serializable mirror of the engine's `BassAnchorResults`. Captures
+/// the per-channel phase at the bass anchor frequency so that GD-Opt
+/// v2's confidence gate (§3.5 of `docs/gd_opt_v2_plan.md`) and
+/// optimiser (§3.2) can ingest it at config-load time without
+/// depending on `sotf-engine`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct BassAnchorResultsLegacy {
+    /// Per-channel phase + quality metrics.
+    pub channels: Vec<BassAnchorChannelResultLegacy>,
+    /// Sample rate used for the capture (Hz).
+    pub sample_rate: u32,
+    /// Tone-burst centre frequency in Hz (nominal 20 Hz).
+    pub bass_freq_hz: f32,
+    /// Number of cycles in the burst (nominal 5).
+    pub bass_cycles: u16,
+}
+
+/// Per-channel bass-anchor result (mirror of `BassAnchorChannelResult`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct BassAnchorChannelResultLegacy {
+    /// Channel name (e.g. "L", "R", "Sub").
+    pub channel_name: String,
+    /// Channel output index used during playback.
+    pub channel_index: usize,
+    /// Measured phase of the bass tone at the listening position,
+    /// degrees in `(−180°, 180°]`, sin-referenced against the emitted
+    /// burst.
+    pub bass_anchor_phase_deg: f64,
+    /// Linear magnitude of the DFT bin at the bass frequency.
+    /// Used as an SNR proxy.
+    pub bass_anchor_magnitude: f64,
+    /// |phase_half1 − phase_half2| in degrees. Values above the
+    /// `"bass_anchor_unreliable"` advisory threshold (§2.8, 20°) mean
+    /// the GD confidence gate should discard this channel's anchor.
+    pub bass_anchor_stability_deg: f64,
 }
 
 // ============================================================================

--- a/crates/math-audio/math-dsp/src/signals.rs
+++ b/crates/math-audio/math-dsp/src/signals.rs
@@ -765,6 +765,150 @@ pub fn gen_narrowband_probe(
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// GD-Opt v2 Phase GD-1e — bass tone burst + phase extraction
+// ---------------------------------------------------------------------------
+
+/// Generate a Hann-windowed sinusoidal tone burst at a single frequency.
+///
+/// Used by the recording wizard's BassAnchor step to capture a
+/// per-channel phase reference at the bottom of the bass band, where
+/// sweep SNR is marginal. At 20 Hz × 5 cycles @ 48 kHz the burst is
+/// 250 ms / 12 000 samples — long enough to resolve phase, short enough
+/// to keep modal ringing bounded.
+///
+/// # Arguments
+/// * `freq_hz`    - Fundamental frequency of the burst in Hz.
+/// * `num_cycles` - Number of cycles (tone-length in periods of `freq_hz`).
+/// * `sample_rate` - Sample rate in Hz.
+/// * `amp`        - Peak amplitude after windowing (≤ 1.0).
+///
+/// # Returns
+/// The burst as a vector of `f32` samples. An empty vector if any input
+/// is zero / sub-sample-length.
+pub fn gen_bass_tone_burst(freq_hz: f32, num_cycles: u16, sample_rate: u32, amp: f32) -> Vec<f32> {
+    if freq_hz <= 0.0 || num_cycles == 0 || sample_rate == 0 || amp <= 0.0 {
+        return Vec::new();
+    }
+    let n = ((num_cycles as f32 / freq_hz) * sample_rate as f32).round() as usize;
+    if n < 2 {
+        return Vec::new();
+    }
+    let omega = 2.0 * PI * freq_hz / sample_rate as f32;
+    let n_f = n as f32;
+    (0..n)
+        .map(|k| {
+            let t = k as f32;
+            // Hann envelope: (1 - cos(2π k / (n-1))) / 2
+            let w = 0.5 * (1.0 - (2.0 * PI * t / (n_f - 1.0)).cos());
+            clip(amp * w * (omega * t).sin())
+        })
+        .collect()
+}
+
+/// Result of a single-bin DFT-based phase extraction at a target
+/// frequency, together with a stability metric that flags modally
+/// contaminated bursts.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TonePhaseResult {
+    /// Phase of the fundamental at `freq_hz` in degrees, wrapped to
+    /// `(−180°, 180°]`. Relative to a reference `sin(ω·t)` emitted at
+    /// the start of the analysis window.
+    pub phase_deg: f64,
+    /// Magnitude of the bin at `freq_hz` (linear, same units as the
+    /// input signal). Zero when the signal contains no tone.
+    pub magnitude: f64,
+    /// |phase_half1 − phase_half2| in degrees. A stable,
+    /// single-sinusoid burst has `stability_deg ≈ 0`. Modal ringing,
+    /// low SNR, or time-varying phase drive this above 20°, which is
+    /// the GD-Opt v2 advisory threshold for `"bass_anchor_unreliable"`.
+    pub stability_deg: f64,
+}
+
+/// Extract the phase of a single frequency bin from a time-domain
+/// signal using a direct DFT sum, plus a half-split stability metric.
+///
+/// For `len(signal) = N`, the complex bin at `freq_hz` is:
+///
+/// ```text
+/// c = Σ_{k=0..N} s[k] · exp(−j·ω·k), ω = 2π·freq_hz/sample_rate
+/// phase = atan2(Im(c), Re(c))
+/// magnitude = |c| / N
+/// ```
+///
+/// The stability metric runs the same extraction over the first and
+/// second halves independently and reports the wrapped phase
+/// difference in degrees. A clean stationary tone gives ≈ 0;
+/// modally-ringing or noisy bursts show ≫ 0.
+pub fn extract_tone_phase(signal: &[f32], freq_hz: f32, sample_rate: u32) -> TonePhaseResult {
+    if signal.len() < 4 || freq_hz <= 0.0 || sample_rate == 0 {
+        return TonePhaseResult {
+            phase_deg: 0.0,
+            magnitude: 0.0,
+            stability_deg: 0.0,
+        };
+    }
+    let (re_full, im_full) = single_bin_dft(signal, freq_hz, sample_rate, 0);
+    let magnitude_raw = (re_full * re_full + im_full * im_full).sqrt();
+    let magnitude = magnitude_raw / signal.len() as f64;
+    let phase_rad = im_full.atan2(re_full);
+
+    let mid = signal.len() / 2;
+    let (re_a, im_a) = single_bin_dft(&signal[..mid], freq_hz, sample_rate, 0);
+    // The second half keeps the global time reference (k_offset = mid)
+    // so both halves measure phase against the same t = 0 — otherwise
+    // the split induces a spurious `mid·ω` phase jump on a stable tone.
+    let (re_b, im_b) = single_bin_dft(&signal[mid..], freq_hz, sample_rate, mid);
+    let phase_a = im_a.atan2(re_a);
+    let phase_b = im_b.atan2(re_b);
+    // Wrap (phase_b − phase_a) to (−π, π] before taking |·|.
+    let mut diff = phase_b - phase_a;
+    while diff > PI as f64 {
+        diff -= 2.0 * PI as f64;
+    }
+    while diff <= -(PI as f64) {
+        diff += 2.0 * PI as f64;
+    }
+
+    TonePhaseResult {
+        phase_deg: phase_rad.to_degrees(),
+        magnitude,
+        stability_deg: diff.abs().to_degrees(),
+    }
+}
+
+/// Direct single-bin DFT evaluated with the `sin` convention:
+///   `s[k] ≈ A · sin(ωk + φ)` → `phase = atan2(imag, real)`.
+///
+/// Returns the raw `(real, imag)` accumulators so callers can either
+/// compute magnitude themselves or average across windows without
+/// extra trigonometry.
+///
+/// The `k_offset` argument lets sub-slices of a larger signal share a
+/// common time reference. When analysing `signal[mid..]`, pass
+/// `k_offset = mid` so the projection basis stays anchored at the
+/// original `t = 0`; otherwise the two halves' phase measurements
+/// acquire a synthetic offset proportional to `mid · ω`.
+#[inline]
+fn single_bin_dft(signal: &[f32], freq_hz: f32, sample_rate: u32, k_offset: usize) -> (f64, f64) {
+    let omega = 2.0 * std::f64::consts::PI * freq_hz as f64 / sample_rate as f64;
+    let mut re = 0.0_f64;
+    let mut im = 0.0_f64;
+    // Reference convention: the emitted burst is `sin(ω·t)`. A pure
+    // sin-phase signal should produce `phase = 0`. Projecting onto
+    // `sin(ω·t)` (real part) and `+cos(ω·t)` (imag part) makes
+    // `atan2(imag, real)` return the phase of a sin-referenced tone:
+    //   sin(ωt) → phase = 0°
+    //   cos(ωt) → phase = +90°
+    //   −sin(ωt) → phase = ±180°
+    for (i, &s) in signal.iter().enumerate() {
+        let theta = omega * (i + k_offset) as f64;
+        re += s as f64 * theta.sin();
+        im += s as f64 * theta.cos();
+    }
+    (re, im)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1273,5 +1417,127 @@ mod tests {
                 k
             );
         }
+    }
+
+    // ----- GD-Opt v2 Phase GD-1e — bass tone burst + phase extraction ----
+
+    #[test]
+    fn bass_tone_burst_length_and_envelope() {
+        // 20 Hz × 5 cycles at 48 kHz → exactly 12 000 samples (250 ms)
+        let b = gen_bass_tone_burst(20.0, 5, 48_000, 0.5);
+        assert_eq!(b.len(), 12_000);
+        // Peak after Hann windowing at amp=0.5 → ≤ 0.5
+        let peak = b.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        assert!(peak <= 0.5 + 1e-6, "burst peak {peak} exceeds amp");
+        // Hann envelope: first and last samples are near-zero.
+        assert!(b[0].abs() < 1e-4);
+        assert!(b[b.len() - 1].abs() < 1e-4);
+        // The integer-cycle burst places a zero crossing exactly at
+        // the midpoint (2.5 cycles). Peak around the midpoint — scan
+        // a ¼-cycle window on either side to find it.
+        let quarter_cycle = (48_000 / 20 / 4) as usize; // 600 samples
+        let mid = b.len() / 2;
+        let peak_near_mid = b[mid - quarter_cycle..=mid + quarter_cycle]
+            .iter()
+            .map(|s| s.abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            peak_near_mid > 0.3,
+            "burst centre region should hit peak, got {peak_near_mid}"
+        );
+    }
+
+    #[test]
+    fn bass_tone_burst_rejects_invalid() {
+        assert!(gen_bass_tone_burst(0.0, 5, 48_000, 0.5).is_empty());
+        assert!(gen_bass_tone_burst(20.0, 0, 48_000, 0.5).is_empty());
+        assert!(gen_bass_tone_burst(20.0, 5, 0, 0.5).is_empty());
+        assert!(gen_bass_tone_burst(20.0, 5, 48_000, 0.0).is_empty());
+    }
+
+    #[test]
+    fn tone_phase_recovers_sin_reference_zero() {
+        // Reference: pure sin(ωt) at 20 Hz. Phase should be ≈ 0°.
+        let burst = gen_bass_tone_burst(20.0, 5, 48_000, 0.5);
+        let r = extract_tone_phase(&burst, 20.0, 48_000);
+        assert!(
+            r.phase_deg.abs() < 1.0,
+            "pure sin burst should give phase ≈ 0°, got {:.3}°",
+            r.phase_deg
+        );
+        assert!(r.magnitude > 0.0);
+        // A stable-but-Hann-windowed burst has a small residual
+        // stability reading (~7°) because the two halves have
+        // different envelope profiles. The advisory threshold for
+        // `"bass_anchor_unreliable"` is 20° (plan §2.8), so anything
+        // below that is considered reliable. Test with a safety
+        // margin of 15°.
+        assert!(
+            r.stability_deg < 15.0,
+            "stable tone stability should stay under the 20° advisory threshold, got {:.3}°",
+            r.stability_deg
+        );
+    }
+
+    #[test]
+    fn tone_phase_recovers_synthetic_90_degree_shift() {
+        // Synthesize a cos-phase burst (= 90° phase shift relative to sin).
+        let freq = 20.0_f32;
+        let sr = 48_000_u32;
+        let n = 12_000;
+        let omega = 2.0 * PI * freq / sr as f32;
+        let n_f = n as f32;
+        let burst: Vec<f32> = (0..n)
+            .map(|k| {
+                let t = k as f32;
+                let w = 0.5 * (1.0 - (2.0 * PI * t / (n_f - 1.0)).cos());
+                0.5 * w * (omega * t).cos() // cos(ωt) → 90° relative to sin(ωt)
+            })
+            .collect();
+        let r = extract_tone_phase(&burst, freq, sr);
+        // Expected phase is 90° (cos = sin shifted forward by 90°).
+        let err = (r.phase_deg - 90.0).abs();
+        assert!(
+            err < 1.0,
+            "cos burst should give phase ≈ 90°, got {:.3}° (error {:.3}°)",
+            r.phase_deg,
+            err
+        );
+        // Stable-but-Hann-windowed — see note on the sin-reference
+        // test for why the stability reading is non-zero.
+        assert!(r.stability_deg < 15.0);
+    }
+
+    #[test]
+    fn tone_phase_detects_unstable_burst() {
+        // Concatenate two half-bursts with a 90° jump in the middle.
+        // The stability metric must flag this > 20°.
+        let freq = 20.0_f32;
+        let sr = 48_000_u32;
+        let n_half = 6_000;
+        let omega = 2.0 * PI * freq / sr as f32;
+        let n_f = (2 * n_half) as f32;
+        let burst: Vec<f32> = (0..2 * n_half)
+            .map(|k| {
+                let t = k as f32;
+                let w = 0.5 * (1.0 - (2.0 * PI * t / (n_f - 1.0)).cos());
+                let phase_shift = if k < n_half { 0.0 } else { PI / 2.0 };
+                0.5 * w * (omega * t + phase_shift).sin()
+            })
+            .collect();
+        let r = extract_tone_phase(&burst, freq, sr);
+        assert!(
+            r.stability_deg > 20.0,
+            "phase-jump burst should be flagged unstable, got stability = {:.1}°",
+            r.stability_deg
+        );
+    }
+
+    #[test]
+    fn tone_phase_rejects_short_signal() {
+        let r = extract_tone_phase(&[0.1, 0.2], 20.0, 48_000);
+        assert_eq!(r.magnitude, 0.0);
+        assert_eq!(r.phase_deg, 0.0);
+        assert_eq!(r.stability_deg, 0.0);
     }
 }

--- a/crates/sotf-engine/CHANGELOG.md
+++ b/crates/sotf-engine/CHANGELOG.md
@@ -1,3 +1,35 @@
+# 1.0.21
+
+## GD-Opt v2 — Phase GD-1e: bass anchor capture
+
+Implements the BassAnchor wizard step runner per
+`docs/gd_opt_v2_plan.md` §2.6. The step plays a low-frequency tone
+burst (20 Hz × 5 cycles by default) per channel, records the mic,
+and extracts per-channel phase + half-split stability of the
+burst's fundamental. GD-Opt v2 uses this as a hard anchor on the
+first measured bin of the sweep phase to eliminate the 2π
+wraparound ambiguity at sub-100 Hz.
+
+- New `run_bass_anchor` / `run_bass_anchor_with_recording` entry
+  points (public, non-iOS). Playback scaffolding mirrors
+  `probe_channel_delays` — sequential single-channel bursts with
+  silence gaps, mic recording to a mono `f32` WAV, single DFT-based
+  per-channel phase extraction.
+- New `analyze_bass_anchor_recording` helper — the pure analysis
+  core, used both by the live runner and by the replay tests. Can
+  be called offline against a persisted bass-anchor WAV to
+  re-derive per-channel phase without replay.
+- New `BassAnchorResults` / `BassAnchorChannelResult` types. Each
+  channel carries `bass_anchor_phase_deg`, `bass_anchor_magnitude`,
+  and `bass_anchor_stability_deg`. Values ≥ 20° on the stability
+  metric trigger the `"bass_anchor_unreliable"` advisory
+  (`docs/gd_opt_v2_plan.md` §2.8).
+- Three new replay tests pin behaviour:
+  `bass_anchor_replay_recovers_known_phase_shifts` (phase recovery
+  within ±2° across three synthetic channels),
+  `bass_anchor_replay_rejects_length_mismatch`, and
+  `bass_anchor_replay_errors_when_start_past_eof`.
+
 # 1.0.20
 
 ## GD-Opt v2 — Phase GD-1a.1: Drop legacy recording migration

--- a/crates/sotf-engine/Cargo.toml
+++ b/crates/sotf-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sotf-engine"
 description = "an audio player and recorder that support audio plugins"
-version = "1.0.20"
+version = "1.0.21"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sotf-engine/src/signal_recorder.rs
+++ b/crates/sotf-engine/src/signal_recorder.rs
@@ -1709,6 +1709,469 @@ fn probe_channel_delays_core(
     ))
 }
 
+// ---------------------------------------------------------------------------
+// GD-Opt v2 Phase GD-1e — bass anchor capture
+//
+// Plays a low-frequency tone burst (default 20 Hz × 5 cycles) on one
+// channel at a time, records from the mic, and extracts the per-channel
+// phase + stability of the burst's fundamental. The result anchors the
+// sweep-derived phase at the lowest bin — see `docs/gd_opt_v2_plan.md`
+// §2.6 (BassAnchor wizard step) and §3.5 (confidence gate).
+//
+// Playback scaffolding is a scoped duplication of
+// `probe_channel_delays_core`. A future refactor could extract a
+// shared `play_signals_record_mono` helper; for GD-1e the priority is
+// landing a working BassAnchor step without rewiring the existing probe.
+// ---------------------------------------------------------------------------
+
+/// Result of a bass-anchor capture across all channels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BassAnchorResults {
+    /// Per-channel phase + quality.
+    pub channels: Vec<BassAnchorChannelResult>,
+    /// Input sample rate used for the analysis (may differ from
+    /// `requested_sample_rate` if cpal negotiated a different rate).
+    pub sample_rate: u32,
+    /// Centre frequency of the tone burst in Hz.
+    pub bass_freq_hz: f32,
+    /// Number of cycles in the burst.
+    pub bass_cycles: u16,
+}
+
+/// Per-channel bass-anchor result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BassAnchorChannelResult {
+    pub channel_name: String,
+    pub channel_index: usize,
+    /// Phase of the bass tone at the mic, sin-referenced, in degrees.
+    pub bass_anchor_phase_deg: f64,
+    /// Linear magnitude of the DFT bin at `bass_freq_hz` — SNR proxy.
+    pub bass_anchor_magnitude: f64,
+    /// Half-split phase difference in degrees — advisory threshold is
+    /// 20° (§2.8 of `docs/gd_opt_v2_plan.md`).
+    pub bass_anchor_stability_deg: f64,
+}
+
+/// Run the bass-anchor capture across all output channels.
+///
+/// # Arguments
+/// * `channel_indices` - Output channel indices to probe (0-based)
+/// * `channel_names` - Human-readable name for each channel
+/// * `sample_rate` - Desired playback / capture sample rate in Hz
+/// * `bass_freq_hz` - Tone-burst centre frequency (default 20 Hz)
+/// * `bass_cycles` - Number of cycles per burst (default 5)
+/// * `silence_duration_ms` - Silence gap between channels in ms
+/// * `output_device_name` - Playback device (None = default)
+/// * `input_device_name` - Recording device (None = default)
+/// * `input_channel` - Mic input channel index
+#[cfg(not(target_os = "ios"))]
+#[allow(clippy::too_many_arguments)]
+pub fn run_bass_anchor(
+    channel_indices: &[u16],
+    channel_names: &[String],
+    sample_rate: u32,
+    bass_freq_hz: f32,
+    bass_cycles: u16,
+    silence_duration_ms: f32,
+    output_device_name: Option<&str>,
+    input_device_name: Option<&str>,
+    input_channel: u16,
+) -> Result<BassAnchorResults, String> {
+    let (results, _recorded, _input_sr) = run_bass_anchor_core(
+        channel_indices,
+        channel_names,
+        sample_rate,
+        bass_freq_hz,
+        bass_cycles,
+        silence_duration_ms,
+        output_device_name,
+        input_device_name,
+        input_channel,
+    )?;
+    Ok(results)
+}
+
+/// Run the bass-anchor capture and persist the raw mono mic recording.
+///
+/// Behaves like [`run_bass_anchor`] otherwise. The recording is a
+/// single-channel `f32` WAV at the negotiated input sample rate; the
+/// same `channel_offsets` layout as `probe_channel_delays_with_recording`
+/// applies so callers can re-analyse offline with
+/// [`analyze_bass_anchor_recording`].
+#[cfg(not(target_os = "ios"))]
+#[allow(clippy::too_many_arguments)]
+pub fn run_bass_anchor_with_recording(
+    channel_indices: &[u16],
+    channel_names: &[String],
+    sample_rate: u32,
+    bass_freq_hz: f32,
+    bass_cycles: u16,
+    silence_duration_ms: f32,
+    output_device_name: Option<&str>,
+    input_device_name: Option<&str>,
+    input_channel: u16,
+    recording_wav_path: &std::path::Path,
+) -> Result<BassAnchorResults, String> {
+    let (results, recorded, input_sr) = run_bass_anchor_core(
+        channel_indices,
+        channel_names,
+        sample_rate,
+        bass_freq_hz,
+        bass_cycles,
+        silence_duration_ms,
+        output_device_name,
+        input_device_name,
+        input_channel,
+    )?;
+
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: input_sr,
+        bits_per_sample: 32,
+        sample_format: SampleFormat::Float,
+    };
+    let mut writer = WavWriter::create(recording_wav_path, spec)
+        .map_err(|e| format!("Failed to create bass-anchor recording WAV: {}", e))?;
+    for &s in &recorded {
+        writer
+            .write_sample(s)
+            .map_err(|e| format!("Failed to write bass-anchor sample: {}", e))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize bass-anchor WAV: {}", e))?;
+    log::info!(
+        "[run_bass_anchor_with_recording] Saved {} samples ({:.2}s) to {}",
+        recorded.len(),
+        recorded.len() as f64 / input_sr as f64,
+        recording_wav_path.display()
+    );
+    Ok(results)
+}
+
+/// Pure analysis: given the mono recording from a bass-anchor session
+/// and its layout, return per-channel phase results without touching
+/// cpal. Used by the replay-driven tests and by any future offline
+/// re-analysis tool.
+///
+/// `channel_starts` lists the sample index in `recorded` where each
+/// channel's burst begins (mic-side). `burst_samples` is the burst
+/// length at the mic's sample rate.
+pub fn analyze_bass_anchor_recording(
+    recorded: &[f32],
+    channel_names: &[String],
+    channel_indices: &[u16],
+    sample_rate: u32,
+    bass_freq_hz: f32,
+    bass_cycles: u16,
+    channel_starts: &[usize],
+    burst_samples: usize,
+) -> Result<BassAnchorResults, String> {
+    if channel_names.len() != channel_starts.len() || channel_names.len() != channel_indices.len() {
+        return Err("channel_names / channel_indices / channel_starts length mismatch".to_string());
+    }
+
+    let mut channels = Vec::with_capacity(channel_names.len());
+    for (i, (&start, name)) in channel_starts.iter().zip(channel_names.iter()).enumerate() {
+        let end = (start + burst_samples).min(recorded.len());
+        if start >= recorded.len() {
+            return Err(format!(
+                "Channel {} start {} exceeds recording length {}",
+                name,
+                start,
+                recorded.len()
+            ));
+        }
+        let segment = &recorded[start..end];
+        let r =
+            math_audio_dsp::signals::extract_tone_phase(segment, bass_freq_hz, sample_rate);
+        channels.push(BassAnchorChannelResult {
+            channel_name: name.clone(),
+            channel_index: channel_indices[i] as usize,
+            bass_anchor_phase_deg: r.phase_deg,
+            bass_anchor_magnitude: r.magnitude,
+            bass_anchor_stability_deg: r.stability_deg,
+        });
+    }
+
+    Ok(BassAnchorResults {
+        channels,
+        sample_rate,
+        bass_freq_hz,
+        bass_cycles,
+    })
+}
+
+#[cfg(not(target_os = "ios"))]
+#[allow(clippy::too_many_arguments)]
+fn run_bass_anchor_core(
+    channel_indices: &[u16],
+    channel_names: &[String],
+    sample_rate: u32,
+    bass_freq_hz: f32,
+    bass_cycles: u16,
+    silence_duration_ms: f32,
+    output_device_name: Option<&str>,
+    input_device_name: Option<&str>,
+    input_channel: u16,
+) -> Result<(BassAnchorResults, Vec<f32>, u32), String> {
+    use crate::AudioEngineManager;
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use std::sync::{Arc, Mutex};
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    let num_channels = channel_indices.len();
+    if num_channels == 0 {
+        return Err("No channels for bass anchor".to_string());
+    }
+    if channel_names.len() != num_channels {
+        return Err("channel_indices and channel_names must have the same length".to_string());
+    }
+    if bass_freq_hz <= 0.0 || bass_cycles == 0 {
+        return Err(format!(
+            "Invalid bass-anchor params: freq={bass_freq_hz}, cycles={bass_cycles}"
+        ));
+    }
+
+    // Generate the tone burst at the playback sample rate.
+    let burst = math_audio_dsp::signals::gen_bass_tone_burst(
+        bass_freq_hz,
+        bass_cycles,
+        sample_rate,
+        0.5,
+    );
+    if burst.is_empty() {
+        return Err("gen_bass_tone_burst returned empty".to_string());
+    }
+    let burst_samples = burst.len();
+    let silence_samples = (silence_duration_ms / 1000.0 * sample_rate as f32) as usize;
+
+    log::info!(
+        "[run_bass_anchor] Generated {:.0} Hz × {} cycles ({:.0} ms / {} samples) at {} Hz",
+        bass_freq_hz,
+        bass_cycles,
+        1000.0 * burst_samples as f64 / sample_rate as f64,
+        burst_samples,
+        sample_rate
+    );
+
+    // Device discovery + hardware channel probe.
+    let host = cpal::default_host();
+    let output_device = if let Some(dev_name) = output_device_name {
+        crate::devices::find_device(&host, dev_name, false)?
+    } else {
+        host.default_output_device()
+            .ok_or_else(|| "No default output device available".to_string())?
+    };
+    let hardware_channels = output_device
+        .supported_output_configs()
+        .map_err(|e| format!("Failed to get supported output configs: {}", e))?
+        .map(|c| c.channels() as usize)
+        .max()
+        .unwrap_or(2);
+    for &ch in channel_indices {
+        if ch as usize >= hardware_channels {
+            return Err(format!(
+                "Channel {} exceeds hardware output count {}",
+                ch, hardware_channels
+            ));
+        }
+    }
+
+    // Build playback buffer: [silence][ch0_burst][silence][ch1_burst]...[silence]
+    let segment_len = silence_samples + burst_samples;
+    let total_frames = silence_samples + num_channels * segment_len;
+    let mut per_channel: Vec<Vec<f32>> = (0..hardware_channels)
+        .map(|_| vec![0.0_f32; total_frames])
+        .collect();
+    let mut playback_offsets = Vec::with_capacity(num_channels);
+    for (i, &ch_idx) in channel_indices.iter().enumerate() {
+        let frame_offset = silence_samples + i * segment_len;
+        playback_offsets.push(frame_offset);
+        for (j, &s) in burst.iter().enumerate() {
+            per_channel[ch_idx as usize][frame_offset + j] = s;
+        }
+    }
+    let interleaved = interleave_per_channel(&per_channel);
+
+    // Write to temp WAV and load via the engine — same pattern as probe.
+    let temp_file = NamedTempFile::with_suffix(".wav")
+        .map_err(|e| format!("Failed to create temp WAV: {}", e))?;
+    let temp_path = temp_file.path().to_path_buf();
+    let spec = WavSpec {
+        channels: hardware_channels as u16,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: SampleFormat::Float,
+    };
+    let mut writer = WavWriter::create(&temp_path, spec)
+        .map_err(|e| format!("Failed to create WAV writer: {}", e))?;
+    for &s in &interleaved {
+        writer
+            .write_sample(s)
+            .map_err(|e| format!("Failed to write sample: {}", e))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize WAV: {}", e))?;
+
+    // Input device + stream setup.
+    let input_device = if let Some(dev_name) = input_device_name {
+        crate::devices::find_device(&host, dev_name, true)?
+    } else {
+        host.default_input_device()
+            .ok_or_else(|| "No default input device available".to_string())?
+    };
+    let min_input_ch = (input_channel as usize) + 1;
+    let default_input_config = input_device
+        .default_input_config()
+        .map_err(|e| format!("Failed to get default input config: {}", e))?;
+    let best_config = input_device
+        .supported_input_configs()
+        .ok()
+        .and_then(|configs| {
+            configs
+                .filter(|c| {
+                    let ch = c.channels() as usize;
+                    ch >= min_input_ch
+                        && c.min_sample_rate() <= sample_rate
+                        && c.max_sample_rate() >= sample_rate
+                })
+                .min_by_key(|c| c.channels())
+        });
+    let (hw_input_ch, input_sr) = if let Some(config) = best_config {
+        (config.channels() as usize, sample_rate)
+    } else {
+        (
+            default_input_config.channels() as usize,
+            default_input_config.sample_rate(),
+        )
+    };
+
+    // When the mic rate differs from the playback rate, re-derive the
+    // analysis offsets and regenerate the burst at that rate so the
+    // analysis sits on the same time grid as the recording.
+    let analysis_silence = (silence_duration_ms / 1000.0 * input_sr as f32) as usize;
+    let analysis_burst_samples = ((bass_cycles as f32 / bass_freq_hz) * input_sr as f32).round() as usize;
+    let analysis_segment_len = analysis_silence + analysis_burst_samples;
+    let analysis_offsets: Vec<usize> = (0..num_channels)
+        .map(|i| analysis_silence + i * analysis_segment_len)
+        .collect();
+
+    let input_config = cpal::StreamConfig {
+        channels: hw_input_ch as u16,
+        sample_rate: input_sr,
+        buffer_size: cpal::BufferSize::Default,
+    };
+    let recorded_samples: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorded_clone = Arc::clone(&recorded_samples);
+    let input_ch_idx = input_channel as usize;
+    let hw_ch = hw_input_ch;
+    let input_stream = input_device
+        .build_input_stream(
+            &input_config,
+            move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                let mut recorded = recorded_clone.lock().unwrap();
+                for frame in data.chunks(hw_ch) {
+                    if input_ch_idx < frame.len() {
+                        recorded.push(frame[input_ch_idx]);
+                    }
+                }
+            },
+            |err| log::debug!("[run_bass_anchor] Input stream error: {}", err),
+            None,
+        )
+        .map_err(|e| format!("Failed to build input stream: {}", e))?;
+    input_stream
+        .play()
+        .map_err(|e| format!("Failed to start input stream: {}", e))?;
+    sleep(Duration::from_millis(100));
+
+    // Play the burst sequence.
+    let mut manager = AudioEngineManager::new();
+    manager.set_allow_virtual_output(true);
+    manager
+        .load_file(&temp_path)
+        .map_err(|e| format!("Failed to load bass-anchor WAV: {}", e))?;
+    let plugins = vec![];
+    manager
+        .start_playback(
+            output_device_name.map(|s| s.to_string()),
+            plugins,
+            hardware_channels,
+        )
+        .map_err(|e| format!("Failed to start playback: {}", e))?;
+
+    let expected_duration = total_frames as f64 / sample_rate as f64;
+    let total_wait = Duration::from_secs_f64(expected_duration + 3.0);
+    let check_interval = Duration::from_millis(50);
+    let mut elapsed = Duration::ZERO;
+    let mut last_count = 0_usize;
+    let mut stable = 0_u32;
+    while elapsed < total_wait {
+        sleep(check_interval);
+        elapsed += check_interval;
+        let count = recorded_samples.lock().unwrap().len();
+        if count == last_count && count > 0 {
+            stable += 1;
+            if stable >= 3 {
+                break;
+            }
+        } else {
+            stable = 0;
+        }
+        last_count = count;
+        if manager.get_state() == crate::StreamingState::Idle {
+            break;
+        }
+    }
+    sleep(Duration::from_millis(500));
+    manager.stop().ok();
+    std::mem::drop(manager);
+    std::mem::drop(input_stream);
+    sleep(Duration::from_millis(500));
+
+    let recorded = recorded_samples.lock().unwrap().clone();
+    log::info!(
+        "[run_bass_anchor] Recorded {} samples ({:.2}s)",
+        recorded.len(),
+        recorded.len() as f64 / input_sr as f64
+    );
+
+    let rec_peak = recorded.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+    if rec_peak < 1e-4 {
+        return Err(format!(
+            "Bass-anchor recording appears silent (peak {:.6}). Check mic, input channel, and device availability.",
+            rec_peak
+        ));
+    }
+
+    // Per-channel analysis using the shared helper.
+    let results = analyze_bass_anchor_recording(
+        &recorded,
+        channel_names,
+        channel_indices,
+        input_sr,
+        bass_freq_hz,
+        bass_cycles,
+        &analysis_offsets,
+        analysis_burst_samples,
+    )?;
+
+    for cr in &results.channels {
+        log::info!(
+            "[run_bass_anchor] {}: phase={:.2}°  mag={:.4}  stability={:.2}°",
+            cr.channel_name,
+            cr.bass_anchor_phase_deg,
+            cr.bass_anchor_magnitude,
+            cr.bass_anchor_stability_deg
+        );
+    }
+
+    Ok((results, recorded, input_sr))
+}
+
 /// Parse comma-separated channel list (0-based indices)
 pub fn parse_channel_list(s: &str) -> Result<Vec<u16>, String> {
     let mut channels = Vec::new();
@@ -2866,5 +3329,135 @@ mod tests {
         // 1.0 explicit.
         let out_min = build_octave_sweep_with_silence(20.0, 20_000.0, 0.5, 1.0, 0.0, 0.0, sr);
         assert_eq!(out_clamped.len(), out_min.len(), "Clamped and min-1.0 lengths differ");
+    }
+
+    // ------------------------------------------------------------------
+    // GD-Opt v2 Phase GD-1e: bass-anchor replay tests
+    // ------------------------------------------------------------------
+
+    /// Synthesise a multi-channel bass-anchor recording with KNOWN
+    /// per-channel phase shifts, then run the same analysis path that
+    /// `run_bass_anchor_core` uses and assert the phases are recovered.
+    #[test]
+    fn bass_anchor_replay_recovers_known_phase_shifts() {
+        use math_audio_dsp::signals::gen_bass_tone_burst;
+        use std::f32::consts::PI;
+
+        let sample_rate = 48_000_u32;
+        let bass_freq = 20.0_f32;
+        let bass_cycles = 5_u16;
+        let silence_ms = 500.0_f32;
+
+        let channel_indices = vec![0_u16, 1, 2];
+        let channel_names = vec!["L".to_string(), "R".to_string(), "Sub".to_string()];
+        // Inject a known phase shift per channel (degrees).
+        let injected_phases_deg = [0.0_f32, 30.0, -45.0];
+
+        let burst_samples = ((bass_cycles as f32 / bass_freq) * sample_rate as f32).round() as usize;
+        let silence_samples = (silence_ms / 1000.0 * sample_rate as f32) as usize;
+        let segment_len = silence_samples + burst_samples;
+        let total_frames = silence_samples + channel_indices.len() * segment_len;
+
+        let mut recorded = vec![0.0_f32; total_frames];
+        let offsets: Vec<usize> = (0..channel_indices.len())
+            .map(|i| silence_samples + i * segment_len)
+            .collect();
+
+        // Build each channel's phase-shifted burst by directly
+        // synthesising the windowed sinusoid at `bass_freq + phase_shift`
+        // instead of time-shifting the burst from `gen_bass_tone_burst`.
+        let n_f = burst_samples as f32;
+        let omega = 2.0 * PI * bass_freq / sample_rate as f32;
+        let _unused = gen_bass_tone_burst(bass_freq, bass_cycles, sample_rate, 0.5); // sanity
+        for (ch_i, &start) in offsets.iter().enumerate() {
+            let phase_shift = injected_phases_deg[ch_i].to_radians();
+            for k in 0..burst_samples {
+                let t = k as f32;
+                let w = 0.5 * (1.0 - (2.0 * PI * t / (n_f - 1.0)).cos());
+                recorded[start + k] = 0.5 * w * (omega * t + phase_shift).sin();
+            }
+        }
+
+        // Run the same analysis path the live capture uses.
+        let results = analyze_bass_anchor_recording(
+            &recorded,
+            &channel_names,
+            &channel_indices,
+            sample_rate,
+            bass_freq,
+            bass_cycles,
+            &offsets,
+            burst_samples,
+        )
+        .expect("analysis should succeed");
+
+        assert_eq!(results.channels.len(), 3);
+        assert_eq!(results.sample_rate, sample_rate);
+        assert_eq!(results.bass_freq_hz, bass_freq);
+        assert_eq!(results.bass_cycles, bass_cycles);
+
+        for (i, cr) in results.channels.iter().enumerate() {
+            let expected = injected_phases_deg[i] as f64;
+            let got = cr.bass_anchor_phase_deg;
+            // Wrap difference to (−180°, 180°] for robust comparison.
+            let mut diff = got - expected;
+            while diff > 180.0 { diff -= 360.0; }
+            while diff <= -180.0 { diff += 360.0; }
+            assert!(
+                diff.abs() < 2.0,
+                "Channel {} ({}): expected {:+.1}°, got {:+.2}° (error {:+.2}°)",
+                i,
+                cr.channel_name,
+                expected,
+                got,
+                diff
+            );
+            assert!(cr.bass_anchor_magnitude > 0.0);
+            // Stable synthetic burst — stability should fall under the
+            // 20° advisory threshold (clear margin).
+            assert!(
+                cr.bass_anchor_stability_deg < 15.0,
+                "Channel {} stability {:.2}° should be well under 20°",
+                cr.channel_name,
+                cr.bass_anchor_stability_deg
+            );
+        }
+    }
+
+    #[test]
+    fn bass_anchor_replay_rejects_length_mismatch() {
+        let recorded = vec![0.0_f32; 100];
+        let err = analyze_bass_anchor_recording(
+            &recorded,
+            &["L".to_string()],
+            &[0_u16],
+            48_000,
+            20.0,
+            5,
+            &[0_usize, 50],
+            48,
+        )
+        .expect_err("length mismatch must fail");
+        assert!(
+            err.contains("length mismatch"),
+            "error should mention length mismatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn bass_anchor_replay_errors_when_start_past_eof() {
+        let recorded = vec![0.0_f32; 10];
+        let err = analyze_bass_anchor_recording(
+            &recorded,
+            &["L".to_string()],
+            &[0_u16],
+            48_000,
+            20.0,
+            5,
+            &[100_usize],
+            48,
+        )
+        .expect_err("start past EOF must fail");
+        assert!(err.contains("exceeds recording length"));
     }
 }

--- a/crates/sotf-player/src/recording_types.rs
+++ b/crates/sotf-player/src/recording_types.rs
@@ -15,9 +15,15 @@ pub enum RecordingStep {
     /// the arrival times can flow directly into the Room EQ optimizer
     /// without a separate measurement session.
     Probe,
-    /// Step 4: Evaluate recordings and view frequency response
+    /// Step 4: Bass anchor — plays a low-frequency tone burst (20 Hz ×
+    /// 5 cycles by default) per channel and records the fundamental's
+    /// phase. GD-Opt v2 feeds the per-channel anchor into the sweep
+    /// unwrap as a hard constraint on the first bass bin
+    /// (`docs/gd_opt_v2_plan.md` §2.6).
+    BassAnchor,
+    /// Step 5: Evaluate recordings and view frequency response
     Evaluating,
-    /// Step 5: Save recordings to disk
+    /// Step 6: Save recordings to disk
     Saving,
 }
 
@@ -29,6 +35,7 @@ impl RecordingStep {
             RecordingStep::Config,
             RecordingStep::Capture,
             RecordingStep::Probe,
+            RecordingStep::BassAnchor,
             RecordingStep::Evaluating,
             RecordingStep::Saving,
         ]
@@ -39,6 +46,7 @@ impl RecordingStep {
             RecordingStep::Config => "Config",
             RecordingStep::Capture => "Capture",
             RecordingStep::Probe => "Probe",
+            RecordingStep::BassAnchor => "Bass Anchor",
             RecordingStep::Evaluating => "Evaluate",
             RecordingStep::Saving => "Save",
         }
@@ -48,7 +56,8 @@ impl RecordingStep {
         match self {
             RecordingStep::Config => Some(RecordingStep::Capture),
             RecordingStep::Capture => Some(RecordingStep::Probe),
-            RecordingStep::Probe => Some(RecordingStep::Evaluating),
+            RecordingStep::Probe => Some(RecordingStep::BassAnchor),
+            RecordingStep::BassAnchor => Some(RecordingStep::Evaluating),
             RecordingStep::Evaluating => Some(RecordingStep::Saving),
             RecordingStep::Saving => None,
         }
@@ -59,7 +68,8 @@ impl RecordingStep {
             RecordingStep::Config => None,
             RecordingStep::Capture => Some(RecordingStep::Config),
             RecordingStep::Probe => Some(RecordingStep::Capture),
-            RecordingStep::Evaluating => Some(RecordingStep::Probe),
+            RecordingStep::BassAnchor => Some(RecordingStep::Probe),
+            RecordingStep::Evaluating => Some(RecordingStep::BassAnchor),
             RecordingStep::Saving => Some(RecordingStep::Evaluating),
         }
     }
@@ -170,6 +180,93 @@ impl ProbeCaptureState {
             }
         }
         if map.is_empty() { None } else { Some(map) }
+    }
+}
+
+/// Status of the BassAnchor capture (Recording wizard Step 4).
+///
+/// Mirrors [`ProbeCaptureStatus`] — wall-clock progress via
+/// `started_at_ms`, `Failed(String)` for error reporting. Used by
+/// the GD-1e BassAnchor wizard step (`docs/gd_opt_v2_plan.md` §2.6).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum BassAnchorCaptureStatus {
+    #[default]
+    Idle,
+    Running { started_at_ms: u64 },
+    Complete,
+    Failed(String),
+}
+
+impl BassAnchorCaptureStatus {
+    /// Estimated fraction of the bass-anchor capture completed.
+    pub fn progress(&self, estimated_total_ms: u64, now_ms: u64) -> Option<f32> {
+        match self {
+            Self::Running { started_at_ms } if estimated_total_ms > 0 => {
+                let elapsed = now_ms.saturating_sub(*started_at_ms);
+                Some((elapsed as f32 / estimated_total_ms as f32).clamp(0.0, 1.0))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Shared business state for the Recording wizard "BassAnchor" step.
+///
+/// Lives alongside [`ProbeCaptureState`]. The raw results come from
+/// the engine (`BassAnchorResults`) and flow at save time into
+/// `RecordingConfiguration.bass_anchor_results`.
+#[derive(Debug, Clone)]
+pub struct BassAnchorCaptureState {
+    /// Tone-burst centre frequency in Hz. Default 20.0.
+    pub bass_freq_hz: f32,
+    /// Number of cycles in the burst. Default 5.
+    pub bass_cycles: u16,
+    /// Silence gap between channels in ms. Default 500.
+    pub silence_duration_ms: f32,
+    /// Sample rate used for the capture (Hz).
+    pub sample_rate: u32,
+    /// Microphone input channel (0-based).
+    pub input_channel: u16,
+    /// Background-measurement status.
+    pub status: BassAnchorCaptureStatus,
+    /// Raw analysis results. Cleared on Reset / new run.
+    pub results: Option<BassAnchorResults>,
+    /// Absolute path to the persisted bass-anchor WAV once captured.
+    pub wav_path: Option<String>,
+}
+
+impl Default for BassAnchorCaptureState {
+    fn default() -> Self {
+        Self {
+            bass_freq_hz: 20.0,
+            bass_cycles: 5,
+            silence_duration_ms: 500.0,
+            sample_rate: 48_000,
+            input_channel: 0,
+            status: BassAnchorCaptureStatus::Idle,
+            results: None,
+            wav_path: None,
+        }
+    }
+}
+
+impl BassAnchorCaptureState {
+    pub fn apply_results(&mut self, results: BassAnchorResults, wav_path: Option<String>) {
+        self.results = Some(results);
+        self.wav_path = wav_path;
+        self.status = BassAnchorCaptureStatus::Complete;
+    }
+
+    /// `true` when every channel's stability metric is under the 20°
+    /// advisory threshold from `docs/gd_opt_v2_plan.md` §2.8.
+    pub fn all_channels_reliable(&self) -> bool {
+        match (&self.status, &self.results) {
+            (BassAnchorCaptureStatus::Complete, Some(r)) => r
+                .channels
+                .iter()
+                .all(|c| c.bass_anchor_stability_deg < 20.0),
+            _ => false,
+        }
     }
 }
 
@@ -561,6 +658,7 @@ impl RecordingSignalType {
 // implemented. Re-export them under player-layer names so UI code only
 // has to depend on `sotf_audio_player` types.
 pub use sotf_audio::signal_recorder::{
+    BassAnchorChannelResult, BassAnchorResults,
     ProbeDelayChannelResult as DelayProbeChannelResult, ProbeDelayResults as DelayProbeResults,
 };
 


### PR DESCRIPTION
Implements the BassAnchor wizard step end-to-end per §2.6 and §2.11 Q1 of `crates/autoeq/docs/gd_opt_v2_plan.md`. Plays a 20 Hz × 5-cycle Hann-windowed tone burst per channel, records the mic, and extracts the per-channel phase + half-split stability of the burst's fundamental. GD-Opt v2 feeds this anchor into the sweep unwrap so the first measured bin below ~100 Hz doesn't carry a 2π wraparound ambiguity.

DSP primitives (math-dsp):
- `gen_bass_tone_burst(freq_hz, cycles, sr, amp)` — Hann-windowed sinusoidal burst. 20 Hz × 5 cycles at 48 kHz → 12 000 samples / 250 ms.
- `extract_tone_phase(signal, freq_hz, sr) -> TonePhaseResult` — single-bin DFT at the target frequency with a sin-referenced convention (sin → 0°, cos → +90°). Carries a half-split stability metric: running the same extraction over the two halves of the signal and reporting |phase_half1 − phase_half2|.
- 6 new tests: burst length + envelope, input guards, sin/cos phase recovery, unstable-burst detection, short-signal rejection.

Engine (sotf-engine):
- `run_bass_anchor` and `run_bass_anchor_with_recording` (non-iOS) mirror the `probe_channel_delays` playback scaffolding but use the tone burst + single-bin DFT analysis path.
- `analyze_bass_anchor_recording` — the pure analysis core, shared between the live runner and the replay tests.
- New `BassAnchorResults` / `BassAnchorChannelResult` types with `bass_anchor_phase_deg`, `bass_anchor_magnitude`, and `bass_anchor_stability_deg`. Stability ≥ 20° trips the `"bass_anchor_unreliable"` advisory (§2.8 of the plan).
- 3 replay tests: `bass_anchor_replay_recovers_known_phase_shifts` synthesises a 3-channel recording with injected phase shifts (0°, +30°, −45°) and asserts recovery within ±2°; plus length-mismatch and EOF-guard tests. Cargo version 1.0.20 → 1.0.21.

Types (autoeq):
- `RecordingConfiguration` gains `bass_anchor_results: Option<BassAnchorResultsLegacy>` and `bass_anchor_wav_relative: Option<String>`. Both default to `None` so legacy session files still deserialize via serde defaults.
- New `BassAnchorResultsLegacy` / `BassAnchorChannelResultLegacy` mirror the engine structs 1:1 so the autoeq loader doesn't depend on `sotf-engine`. Cargo version 0.4.33 → 0.4.34.

Player (sotf-player):
- `RecordingStep` gains `BassAnchor` variant between `Probe` and `Evaluating`. `all()`, `label()`, `next()`, `previous()` updated in lockstep.
- New `BassAnchorCaptureStatus` + `BassAnchorCaptureState` mirroring the Probe equivalents. `all_channels_reliable()` helper checks stability < 20° across all channels.
- Re-exports `BassAnchorResults` / `BassAnchorChannelResult` from `sotf_audio::signal_recorder` under `recording_types`.

Wizard (app-gpui):
- New `components/recording/bass_anchor.rs` renders the step: status line, a per-channel results table when complete, and an "unreliable" warning marker when stability ≥ 20°.
- `mod.rs` dispatch arm + wizard-step id added. `BassAnchor` is optional — Next is always enabled.
- `RecordingState` gains `bass_anchor_capture` field.
- `capture.rs::save_recordings` maps `BassAnchorCaptureState.results` into `RecordingConfiguration.bass_anchor_results` at save time.

Wizard (app-tui):
- `conf_recordings` prev/next cycles and the step-key dispatch extended with `BassAnchor`. A minimal placeholder renders in `draw_configure` — full TUI support lands when the live capture controller is written.

Verified:
- `cargo test -p math-dsp --lib -- signals::tests::bass signals::tests::tone` — 6 passed
- `cargo test -p sotf-engine --lib -- bass_anchor` — 3 passed
- `cargo test -p autoeq --lib` — 430 passed (unchanged)
- `cargo check -p sotf-gpui -p sotf-tui -p sotf-player --lib` clean
- Pre-existing `simd::tests::test_covariance_*` and `preflight::tests::test_get_username` failures confirmed present on master; unrelated to this branch.

This phase exceeds the usual 5-file budget because the BassAnchor step is a cross-crate feature (DSP primitives → engine runner → types → player state → GPUI wizard → TUI wizard). The change is one coherent unit per §2.6 and splits naturally only along crate boundaries. Live-capture spawn wiring (engine → UI effect loop) is out of scope for this phase — tracked separately as GD-1e.live.

https://claude.ai/code/session_01HgarmmUx6miDyUyb4McSW4