### PR TITLE
feat: GD-Opt v2 Phase GD-1e.5 — SplCalibration wizard step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10347,7 +10347,7 @@ dependencies = [
 
 [[package]]
 name = "sotf-engine"
-version = "1.0.21"
+version = "1.0.23"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/crates/app-gpui/app/types/recording.rs
+++ b/crates/app-gpui/app/types/recording.rs
@@ -11,7 +11,7 @@ pub use sotf_audio_player::recording_types::{
     BassAnchorCaptureState, BassAnchorCaptureStatus, ChannelMapping, ChannelRecording,
     ChannelRecordingState, PlaybackDeviceConfig, PlotSmoothing, ProbeCaptureState,
     ProbeCaptureStatus, RecordingDeviceConfig, RecordingResult, RecordingSignalType,
-    RecordingStep, SpeakerConfiguration,
+    RecordingStep, SpeakerConfiguration, SplCalibrationCaptureState, SplCalibrationCaptureStatus,
 };
 
 /// Measurement-unit preference for the room-dimensions inputs on the
@@ -99,6 +99,10 @@ pub struct RecordingState {
     /// the BassAnchor wizard step on success; consumed by
     /// `save_recordings` to embed results in the session JSON.
     pub bass_anchor_capture: BassAnchorCaptureState,
+
+    // === SPL Calibration Step State (GD-Opt v2 Phase GD-1e.5) ===
+    /// Shared business state for the SPL calibration step.
+    pub spl_calibration_capture: SplCalibrationCaptureState,
 
     // === UI State ===
     pub playback_device_dropdown_open: bool,
@@ -206,6 +210,7 @@ impl Default for RecordingState {
             recording_base_directory: None,
             probe_capture: ProbeCaptureState::default(),
             bass_anchor_capture: BassAnchorCaptureState::default(),
+            spl_calibration_capture: SplCalibrationCaptureState::default(),
             playback_device_dropdown_open: false,
             recording_device_dropdown_open: false,
             playback_sample_rate_dropdown_open: false,

--- a/crates/app-gpui/components/recording/capture.rs
+++ b/crates/app-gpui/components/recording/capture.rs
@@ -1773,7 +1773,11 @@ impl PlayerView {
                 bass_probe_cycles: None,
                 mic_phase_calibration_path: None,
                 mic_phase_calibration_paths: None,
-                spl_calibration: None,
+                // GD-Opt v2 Phase GD-1e.5 — SPL calibration, when captured
+                // and the user has entered their meter reading.
+                spl_calibration: rec_state
+                    .spl_calibration_capture
+                    .to_spl_calibration(),
                 recording_seed: None,
             };
 

--- a/crates/app-gpui/components/recording/mod.rs
+++ b/crates/app-gpui/components/recording/mod.rs
@@ -15,6 +15,7 @@ mod config;
 mod evaluating;
 mod probe;
 mod saving;
+mod spl_calibration;
 
 use crate::app::types::{RecordingStep, Screen};
 use crate::components::icons::{Icon, IconName};
@@ -40,6 +41,9 @@ impl PlayerView {
 
         let step_content = match current_step {
             RecordingStep::Config => self.render_recording_config_step(cx).into_any_element(),
+            RecordingStep::SplCalibration => self
+                .render_recording_spl_calibration_step(cx)
+                .into_any_element(),
             RecordingStep::Capture => self.render_recording_capture_step(cx).into_any_element(),
             RecordingStep::Probe => self.render_recording_probe_step(cx).into_any_element(),
             RecordingStep::BassAnchor => {
@@ -110,6 +114,7 @@ impl PlayerView {
             .map(|s| {
                 let id = match s {
                     RecordingStep::Config => "config",
+                    RecordingStep::SplCalibration => "spl_calibration",
                     RecordingStep::Capture => "capture",
                     RecordingStep::Probe => "probe",
                     RecordingStep::BassAnchor => "bass_anchor",
@@ -134,6 +139,10 @@ impl PlayerView {
         // Determine if next button should be disabled
         let next_disabled = match current_step {
             RecordingStep::Config => !has_output_dir,
+            // SplCalibration is optional — users without an external
+            // SPL meter can skip it and GD-Opt v2 degrades the
+            // `"no_spl_calibration"` advisory rather than refusing.
+            RecordingStep::SplCalibration => false,
             RecordingStep::Capture => !all_recorded || is_recording,
             // Probe is optional; always allow advancing past it.
             RecordingStep::Probe => false,

--- a/crates/app-gpui/components/recording/spl_calibration.rs
+++ b/crates/app-gpui/components/recording/spl_calibration.rs
@@ -1,0 +1,205 @@
+//! Recording wizard — Step 2: SPL Calibration (GD-Opt v2 Phase GD-1e.5).
+//!
+//! Plays a 1 kHz reference tone on a single output channel; while it
+//! plays the user reads the dBSPL their external meter shows at the
+//! listening position and types it in. The captured
+//! `(rms_sample_level, reported_db_spl)` pair gives GD-Opt v2 a
+//! deterministic map from digital level to dBSPL at the mic, which
+//! `sweep_level_db_spl` targets during the Capture step.
+//!
+//! See `docs/gd_opt_v2_plan.md` §2.6 and §2.11 Q4 for the calibration
+//! rationale and the "require SPL cap" decision.
+//!
+//! The live capture follows the same `smol::unblock + state.update`
+//! pattern the probe and bass-anchor steps use.
+
+use crate::app::types::recording::SplCalibrationCaptureStatus;
+use crate::ui::PlayerView;
+use gpui::{Context, IntoElement};
+use gpui_ui_kit::{
+    Button, ButtonSize, ButtonVariant, Card, StackSpacing, Text, TextSize, TextWeight, VStack,
+};
+
+impl PlayerView {
+    /// Render the SPL calibration step UI.
+    pub(crate) fn render_recording_spl_calibration_step(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let theme = state.app.ui_state.theme.clone();
+        let rec = &state.app.measurement_state.recording_state;
+        let cal = rec.spl_calibration_capture.clone();
+        let running = matches!(cal.status, SplCalibrationCaptureStatus::Running { .. });
+
+        let status_line = match &cal.status {
+            SplCalibrationCaptureStatus::Idle => format!(
+                "Ready — {:.0} Hz @ amp {:.3} for {:.1}s on ch {}",
+                cal.reference_freq_hz, cal.tone_amp, cal.duration_s, cal.output_channel
+            ),
+            SplCalibrationCaptureStatus::Running { .. } => "Tone playing — read your SPL meter now…".to_string(),
+            SplCalibrationCaptureStatus::Complete => {
+                let er = cal.engine_result.as_ref();
+                match er {
+                    Some(r) => format!(
+                        "Tone captured — peak {:.4}, RMS {:.4}. Enter the dBSPL your meter showed.",
+                        r.peak_sample_level, r.rms_sample_level
+                    ),
+                    None => "Complete".to_string(),
+                }
+            }
+            SplCalibrationCaptureStatus::Failed(e) => format!("Failed: {e}"),
+        };
+
+        let view = cx.entity().clone();
+        let button_label = match cal.status {
+            SplCalibrationCaptureStatus::Idle | SplCalibrationCaptureStatus::Failed(_) => {
+                "Play calibration tone"
+            }
+            SplCalibrationCaptureStatus::Running { .. } => "Playing…",
+            SplCalibrationCaptureStatus::Complete => "Re-play tone",
+        };
+        let start_button = Button::new("spl-cal-start", button_label)
+            .variant(ButtonVariant::Primary)
+            .size(ButtonSize::Md)
+            .disabled(running)
+            .on_click({
+                let view = view.clone();
+                move |_, cx| {
+                    let _ = view.update(cx, |this, cx| this.start_spl_calibration_capture(cx));
+                }
+            });
+
+        let mut column = VStack::new()
+            .spacing(StackSpacing::Sm)
+            .child(
+                Text::new("SPL Calibration")
+                    .weight(TextWeight::Bold)
+                    .size(TextSize::Md),
+            )
+            .child(
+                Text::new(
+                    "Play a 1 kHz reference tone, read the dBSPL your handheld meter shows at \
+                     the listening position, and type the number below. GD-Opt v2 uses the \
+                     offset to target sweep levels deterministically so the subwoofer doesn't \
+                     get pushed into harmonic distortion that would contaminate bass phase.",
+                )
+                .size(TextSize::Sm),
+            )
+            .child(Text::new(status_line).size(TextSize::Sm))
+            .child(start_button);
+
+        if let Some(r) = cal.engine_result.as_ref() {
+            let reported = cal.reported_db_spl;
+            let reported_line = match reported {
+                Some(v) => format!("Reported dBSPL: {v:.1}"),
+                None => "Reported dBSPL: (not entered yet — type it in the UI entry below)"
+                    .to_string(),
+            };
+            column = column
+                .child(
+                    Text::new(format!(
+                        "Ref freq {:.0} Hz  •  sample rate {} Hz  •  peak {:.4}  •  RMS {:.4}",
+                        r.reference_freq_hz, r.sample_rate, r.peak_sample_level, r.rms_sample_level
+                    ))
+                    .size(TextSize::Sm),
+                )
+                .child(Text::new(reported_line).size(TextSize::Sm));
+            if let Some(cal_out) = cal.to_spl_calibration() {
+                column = column.child(
+                    Text::new(format!(
+                        "→ spl_offset_db = {:.2}  (stored on save)",
+                        cal_out.spl_offset_db
+                    ))
+                    .size(TextSize::Sm),
+                );
+            }
+        }
+
+        Card::new()
+            .background(theme.surface)
+            .border(theme.border)
+            .content(column)
+    }
+
+    /// Spawn the SPL calibration capture on a `smol::unblock` worker.
+    /// Result is applied back onto `state` via `apply_engine_result`;
+    /// the UI surfaces the engine's peak/RMS numbers and waits for
+    /// the user to type the meter reading before the cal is "ready".
+    pub(crate) fn start_spl_calibration_capture(&mut self, cx: &mut Context<Self>) {
+        let (
+            reference_freq_hz,
+            tone_amp,
+            duration_s,
+            sample_rate,
+            output_channel,
+            input_channel,
+            out_dev,
+            in_dev,
+        ) = {
+            let state = self.state.read(cx);
+            let rec = &state.app.measurement_state.recording_state;
+            let cal = &rec.spl_calibration_capture;
+            (
+                cal.reference_freq_hz,
+                cal.tone_amp,
+                cal.duration_s,
+                cal.sample_rate,
+                cal.output_channel,
+                cal.input_channel,
+                Some(rec.playback_config.device_name.clone()),
+                Some(rec.recording_config.device_name.clone()),
+            )
+        };
+
+        let started_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        self.state.update(cx, |state, cx| {
+            let cal = &mut state
+                .app
+                .measurement_state
+                .recording_state
+                .spl_calibration_capture;
+            cal.status = SplCalibrationCaptureStatus::Running { started_at_ms };
+            cal.engine_result = None;
+            cx.notify();
+        });
+
+        let state_clone = self.state.clone();
+        cx.spawn(async move |_, cx| {
+            let result = smol::unblock(move || {
+                sotf_audio::signal_recorder::run_spl_calibration(
+                    output_channel,
+                    sample_rate,
+                    reference_freq_hz,
+                    tone_amp,
+                    duration_s,
+                    out_dev.as_deref(),
+                    in_dev.as_deref(),
+                    input_channel,
+                )
+            })
+            .await;
+
+            state_clone.update(&mut cx.clone(), |state, cx| {
+                let cal = &mut state
+                    .app
+                    .measurement_state
+                    .recording_state
+                    .spl_calibration_capture;
+                match result {
+                    Ok(res) => cal.apply_engine_result(res),
+                    Err(e) => {
+                        log::warn!("SPL calibration capture failed: {e}");
+                        cal.status = SplCalibrationCaptureStatus::Failed(e);
+                    }
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+}

--- a/crates/app-tui/events/conf_recordings.rs
+++ b/crates/app-tui/events/conf_recordings.rs
@@ -11,7 +11,8 @@ fn recording_step_prev_wrap(
     use sotf_audio_player::recording_types::RecordingStep;
     match s {
         RecordingStep::Config => RecordingStep::Saving,
-        RecordingStep::Capture => RecordingStep::Config,
+        RecordingStep::SplCalibration => RecordingStep::Config,
+        RecordingStep::Capture => RecordingStep::SplCalibration,
         RecordingStep::Probe => RecordingStep::Capture,
         RecordingStep::BassAnchor => RecordingStep::Probe,
         RecordingStep::Evaluating => RecordingStep::BassAnchor,
@@ -24,7 +25,8 @@ fn recording_step_next_wrap(
 ) -> sotf_audio_player::recording_types::RecordingStep {
     use sotf_audio_player::recording_types::RecordingStep;
     match s {
-        RecordingStep::Config => RecordingStep::Capture,
+        RecordingStep::Config => RecordingStep::SplCalibration,
+        RecordingStep::SplCalibration => RecordingStep::Capture,
         RecordingStep::Capture => RecordingStep::Probe,
         RecordingStep::Probe => RecordingStep::BassAnchor,
         RecordingStep::BassAnchor => RecordingStep::Evaluating,
@@ -370,6 +372,14 @@ pub fn handle_recording_keys(app: &mut App, key: KeyEvent) -> Option<PlayerComma
             // GD-Opt v2 Phase GD-1e — display-only in the TUI for now.
             // Navigation keys fall through to the wizard-level handler
             // via the outer loop; no step-specific actions yet.
+            None
+        }
+
+        RecordingStep::SplCalibration => {
+            // GD-Opt v2 Phase GD-1e.5 — display-only in the TUI for
+            // now. The GPUI wizard carries the full step; the TUI
+            // surface will catch up in a follow-up once the meter-
+            // reading input widget is designed.
             None
         }
 

--- a/crates/app-tui/tests/test_events_navigation.rs
+++ b/crates/app-tui/tests/test_events_navigation.rs
@@ -1126,11 +1126,20 @@ mod tests {
         app.recording.output_directory = "/tmp/test".to_string();
         app.recording.step_tab_focused = true;
 
+        // Cycle order matches `RecordingStep::all()` —
+        // Config → SplCalibration → Capture → Probe → BassAnchor →
+        // Evaluating → Saving → Config.
+        send_keys(&mut app, &[KeyCode::Right]);
+        assert_eq!(app.recording.step, RecordingStep::SplCalibration);
+
         send_keys(&mut app, &[KeyCode::Right]);
         assert_eq!(app.recording.step, RecordingStep::Capture);
 
         send_keys(&mut app, &[KeyCode::Right]);
         assert_eq!(app.recording.step, RecordingStep::Probe);
+
+        send_keys(&mut app, &[KeyCode::Right]);
+        assert_eq!(app.recording.step, RecordingStep::BassAnchor);
 
         send_keys(&mut app, &[KeyCode::Right]);
         assert_eq!(app.recording.step, RecordingStep::Evaluating);

--- a/crates/app-tui/ui/draw_configure.rs
+++ b/crates/app-tui/ui/draw_configure.rs
@@ -627,6 +627,19 @@ pub(crate) fn draw_recording_screen(f: &mut Frame, area: Rect, app: &App) {
             f.render_widget(para, content);
         }
 
+        RecordingStep::SplCalibration => {
+            // GD-Opt v2 Phase GD-1e.5 — placeholder; the GPUI wizard
+            // carries the full step. TUI support lands alongside the
+            // reading-entry widget redesign.
+            use ratatui::widgets::Paragraph;
+            let para = Paragraph::new(
+                "SPL Calibration (GD-Opt v2) — optional but recommended. Displayed in the \
+                 GPUI wizard; TUI support arrives with the meter-reading input widget.",
+            )
+            .wrap(ratatui::widgets::Wrap { trim: true });
+            f.render_widget(para, content);
+        }
+
         RecordingStep::Evaluating => {
             let inner = Layout::default()
                 .direction(Direction::Vertical)

--- a/crates/sotf-engine/CHANGELOG.md
+++ b/crates/sotf-engine/CHANGELOG.md
@@ -1,3 +1,34 @@
+# 1.0.23
+
+## GD-Opt v2 — Phase GD-1e.5: SPL calibration capture
+
+Adds `run_spl_calibration` — plays a single-frequency reference tone
+(1 kHz default) on one output channel while recording the mic, then
+returns peak + RMS sample levels over the stable portion of the
+tone. The UI uses the paired `(rms_sample_level, reported_db_spl)`
+to derive `SplCalibration::spl_offset_db`, the GD-Opt v2 anchor for
+the `sweep_level_db_spl` target (see `docs/gd_opt_v2_plan.md` §2.6
+and §2.11 Q4).
+
+- New public API `run_spl_calibration(output_channel, sample_rate,
+  reference_freq_hz, amp, duration_s, out_dev, in_dev, input_channel)
+  -> Result<SplCalibrationResult, _>`.
+- New public type `SplCalibrationResult { sample_rate,
+  peak_sample_level, rms_sample_level, reference_freq_hz,
+  output_channel }`. Derives Debug/Clone/Serialize/Deserialize so
+  sotf-player can re-export and carry it on the TUI+GPUI state
+  structs.
+- Reuses the existing `play_per_channel_and_record_mono` helper
+  (from 1.0.22's dedup) so all device-discovery + cpal logic stays
+  single-source. The calibration-specific logic is just (a) gen a
+  pure tone via `gen_tone`, (b) after capture, slice a stable
+  analysis window skipping 200 ms of attack/release on each end,
+  (c) compute peak+RMS over that window.
+- Input validation: rejects non-finite / non-positive freq, too-
+  short duration (< 0.3 s), amplitude outside (0, 1].
+
+Cargo version 1.0.22 → 1.0.23.
+
 # 1.0.22
 
 ## GD-Opt v2 — Phase GD-1e dedup: shared playback scaffolding

--- a/crates/sotf-engine/Cargo.toml
+++ b/crates/sotf-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sotf-engine"
 description = "an audio player and recorder that support audio plugins"
-version = "1.0.22"
+version = "1.0.23"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sotf-engine/src/signal_recorder.rs
+++ b/crates/sotf-engine/src/signal_recorder.rs
@@ -2029,6 +2029,128 @@ fn run_bass_anchor_core(
     Ok((results, capture.recorded, capture.input_sr))
 }
 
+// ---------------------------------------------------------------------------
+// GD-Opt v2 Phase GD-1e.5 — SPL calibration capture
+//
+// Plays a single-frequency tone (1 kHz by default) through one output
+// channel while the user reads the dBSPL off an external meter at the
+// listening position. The captured peak / RMS level on the mic gives
+// the `peak_sample_level` that anchors `SplCalibration::spl_offset_db`
+// later on the UI side. See `docs/gd_opt_v2_plan.md` §2.6, §2.11 Q4.
+// ---------------------------------------------------------------------------
+
+/// Result of a single SPL-calibration capture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SplCalibrationResult {
+    /// Sample rate the mic captured at (Hz).
+    pub sample_rate: u32,
+    /// Peak absolute sample value observed on the mic during the tone
+    /// (the stable window — excludes attack/release).
+    pub peak_sample_level: f32,
+    /// RMS sample value over the stable window. More noise-robust
+    /// than the peak and preferred when authoring SplCalibration.
+    pub rms_sample_level: f32,
+    /// Frequency of the tone that was played, echoed back for audit.
+    pub reference_freq_hz: f32,
+    /// Playback output channel index used during the capture.
+    pub output_channel: u16,
+}
+
+/// Play a single-frequency sine wave through `output_channel` while
+/// recording the mic. Returns the mic peak / RMS sample level over
+/// the stable portion of the tone (skipping the first 200 ms of
+/// attack and the last 200 ms of release).
+#[cfg(not(target_os = "ios"))]
+#[allow(clippy::too_many_arguments)]
+pub fn run_spl_calibration(
+    output_channel: u16,
+    sample_rate: u32,
+    reference_freq_hz: f32,
+    amp: f32,
+    duration_s: f32,
+    output_device_name: Option<&str>,
+    input_device_name: Option<&str>,
+    input_channel: u16,
+) -> Result<SplCalibrationResult, String> {
+    if !reference_freq_hz.is_finite() || reference_freq_hz <= 0.0 {
+        return Err(format!(
+            "Invalid SPL cal reference frequency: {reference_freq_hz}"
+        ));
+    }
+    if !duration_s.is_finite() || duration_s <= 0.3 {
+        return Err(format!("SPL cal duration must be > 0.3 s, got {duration_s}"));
+    }
+    if !amp.is_finite() || !(0.0..=1.0).contains(&amp) {
+        return Err(format!("SPL cal amplitude must be in (0, 1], got {amp}"));
+    }
+
+    // Generate a Hann-windowed tone so the start/end don't click.
+    // The 200 ms skirt on each end is ignored during analysis, so the
+    // Hann just avoids hardware popping during attack/release; it
+    // doesn't affect the measured level in the stable window.
+    let tone = gen_tone(reference_freq_hz, amp, sample_rate, duration_s);
+    if tone.is_empty() {
+        return Err("gen_tone returned empty".to_string());
+    }
+
+    log::info!(
+        "[run_spl_calibration] Generated {:.0} Hz tone @ amp={:.3}, {:.1}s ({} samples)",
+        reference_freq_hz,
+        amp,
+        duration_s,
+        tone.len()
+    );
+
+    let capture = play_per_channel_and_record_mono(
+        &[output_channel],
+        sample_rate,
+        &tone,
+        // Short silence so the tone starts cleanly but the whole
+        // capture finishes in a couple of seconds. The stability
+        // window analysis below excludes the first 200 ms anyway.
+        200.0,
+        output_device_name,
+        input_device_name,
+        input_channel,
+        "run_spl_calibration",
+    )?;
+
+    // Slice the mic recording to the stable portion of the tone.
+    // `analysis_offsets[0]` is the first sample of the tone at the
+    // mic's rate; skip an additional 200 ms to let any DAC+mic
+    // transient die and stop 200 ms before the tone ends.
+    let skirt = (0.2 * capture.input_sr as f32) as usize;
+    let start = capture.analysis_offsets[0] + skirt;
+    let end = (capture.analysis_offsets[0] + capture.analysis_signal_samples)
+        .saturating_sub(skirt)
+        .min(capture.recorded.len());
+    if end <= start + skirt {
+        return Err(format!(
+            "[run_spl_calibration] capture too short for stable-window analysis \
+             (start={start}, end={end}, recording={})",
+            capture.recorded.len()
+        ));
+    }
+    let stable = &capture.recorded[start..end];
+
+    let peak = stable.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+    let rms = {
+        let sum_sq: f64 = stable.iter().map(|&s| (s as f64) * (s as f64)).sum();
+        ((sum_sq / stable.len() as f64).sqrt()) as f32
+    };
+
+    log::info!(
+        "[run_spl_calibration] Stable window [{start}..{end}) → peak={peak:.4}, rms={rms:.4}"
+    );
+
+    Ok(SplCalibrationResult {
+        sample_rate: capture.input_sr,
+        peak_sample_level: peak,
+        rms_sample_level: rms,
+        reference_freq_hz,
+        output_channel,
+    })
+}
 
 /// Parse comma-separated channel list (0-based indices)
 pub fn parse_channel_list(s: &str) -> Result<Vec<u16>, String> {

--- a/crates/sotf-player/src/recording_types.rs
+++ b/crates/sotf-player/src/recording_types.rs
@@ -8,22 +8,27 @@ pub enum RecordingStep {
     /// Step 1: Configure devices and channel mapping
     #[default]
     Config,
-    /// Step 2: Record frequency response for each channel
+    /// Step 2: SPL calibration — plays a 1 kHz reference tone; user
+    /// enters the dBSPL their external meter reads at the listening
+    /// position. GD-Opt v2 uses the captured offset to target sweep
+    /// levels deterministically (`docs/gd_opt_v2_plan.md` §2.6, §2.11 Q4).
+    SplCalibration,
+    /// Step 3: Record frequency response for each channel
     Capture,
-    /// Step 3: Tone-burst probe for per-channel acoustic delay detection.
+    /// Step 4: Tone-burst probe for per-channel acoustic delay detection.
     /// Runs once across all channels while the mic is still set up so
     /// the arrival times can flow directly into the Room EQ optimizer
     /// without a separate measurement session.
     Probe,
-    /// Step 4: Bass anchor — plays a low-frequency tone burst (20 Hz ×
+    /// Step 5: Bass anchor — plays a low-frequency tone burst (20 Hz ×
     /// 5 cycles by default) per channel and records the fundamental's
     /// phase. GD-Opt v2 feeds the per-channel anchor into the sweep
     /// unwrap as a hard constraint on the first bass bin
     /// (`docs/gd_opt_v2_plan.md` §2.6).
     BassAnchor,
-    /// Step 5: Evaluate recordings and view frequency response
+    /// Step 6: Evaluate recordings and view frequency response
     Evaluating,
-    /// Step 6: Save recordings to disk
+    /// Step 7: Save recordings to disk
     Saving,
 }
 
@@ -33,6 +38,7 @@ impl RecordingStep {
     pub fn all() -> &'static [RecordingStep] {
         &[
             RecordingStep::Config,
+            RecordingStep::SplCalibration,
             RecordingStep::Capture,
             RecordingStep::Probe,
             RecordingStep::BassAnchor,
@@ -44,6 +50,7 @@ impl RecordingStep {
     pub fn label(&self) -> &'static str {
         match self {
             RecordingStep::Config => "Config",
+            RecordingStep::SplCalibration => "SPL Cal",
             RecordingStep::Capture => "Capture",
             RecordingStep::Probe => "Probe",
             RecordingStep::BassAnchor => "Bass Anchor",
@@ -54,7 +61,8 @@ impl RecordingStep {
 
     pub fn next(&self) -> Option<RecordingStep> {
         match self {
-            RecordingStep::Config => Some(RecordingStep::Capture),
+            RecordingStep::Config => Some(RecordingStep::SplCalibration),
+            RecordingStep::SplCalibration => Some(RecordingStep::Capture),
             RecordingStep::Capture => Some(RecordingStep::Probe),
             RecordingStep::Probe => Some(RecordingStep::BassAnchor),
             RecordingStep::BassAnchor => Some(RecordingStep::Evaluating),
@@ -66,7 +74,8 @@ impl RecordingStep {
     pub fn previous(&self) -> Option<RecordingStep> {
         match self {
             RecordingStep::Config => None,
-            RecordingStep::Capture => Some(RecordingStep::Config),
+            RecordingStep::SplCalibration => Some(RecordingStep::Config),
+            RecordingStep::Capture => Some(RecordingStep::SplCalibration),
             RecordingStep::Probe => Some(RecordingStep::Capture),
             RecordingStep::BassAnchor => Some(RecordingStep::Probe),
             RecordingStep::Evaluating => Some(RecordingStep::BassAnchor),
@@ -267,6 +276,126 @@ impl BassAnchorCaptureState {
                 .all(|c| c.bass_anchor_stability_deg < 20.0),
             _ => false,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GD-Opt v2 Phase GD-1e.5 — SPL calibration step
+// ---------------------------------------------------------------------------
+
+/// Status of the SPL Calibration step (Recording wizard Step 2).
+///
+/// Mirrors the other capture-status enums. `started_at_ms` is
+/// wall-clock; `Failed(String)` carries the engine's reason for the
+/// UI to surface.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum SplCalibrationCaptureStatus {
+    #[default]
+    Idle,
+    Running { started_at_ms: u64 },
+    Complete,
+    Failed(String),
+}
+
+impl SplCalibrationCaptureStatus {
+    pub fn progress(&self, estimated_total_ms: u64, now_ms: u64) -> Option<f32> {
+        match self {
+            Self::Running { started_at_ms } if estimated_total_ms > 0 => {
+                let elapsed = now_ms.saturating_sub(*started_at_ms);
+                Some((elapsed as f32 / estimated_total_ms as f32).clamp(0.0, 1.0))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Shared business state for the SplCalibration step.
+///
+/// Collected from the user across two stages:
+/// 1. Engine plays a reference tone and returns a `SplCalibrationResult`
+///    (peak + RMS sample levels on the mic).
+/// 2. User types the dBSPL their external meter reads while the tone
+///    plays; that becomes `reported_db_spl`. `spl_offset_db` is
+///    derived via
+///    `reported_db_spl − 20 · log10(rms_sample_level)` so that a later
+///    capture at the same digital gain predicts its own dBSPL without
+///    needing the meter.
+///
+/// On save, this state is converted to the `SplCalibration` struct
+/// the autoeq `RecordingConfiguration` carries.
+#[derive(Debug, Clone)]
+pub struct SplCalibrationCaptureState {
+    /// Reference tone frequency (Hz). Default 1000.
+    pub reference_freq_hz: f32,
+    /// Digital amplitude of the reference tone (0.0..=1.0). Default 0.25
+    /// — leaves ~12 dB headroom and reliably hits 75-85 dBSPL on typical
+    /// home systems at normal volume.
+    pub tone_amp: f32,
+    /// Tone duration in seconds. Default 3.0.
+    pub duration_s: f32,
+    /// Sample rate used for the capture (Hz).
+    pub sample_rate: u32,
+    /// Playback output channel (0-based). Default 0 (left / mono).
+    pub output_channel: u16,
+    /// Microphone input channel (0-based).
+    pub input_channel: u16,
+    /// Capture status.
+    pub status: SplCalibrationCaptureStatus,
+    /// Raw engine capture result — `None` until a successful run.
+    pub engine_result: Option<SplCalibrationResult>,
+    /// dBSPL the user read from their external meter. `None` until
+    /// the user has entered a value. Combines with
+    /// `engine_result.rms_sample_level` to compute `spl_offset_db`.
+    pub reported_db_spl: Option<f32>,
+}
+
+impl Default for SplCalibrationCaptureState {
+    fn default() -> Self {
+        Self {
+            reference_freq_hz: 1000.0,
+            tone_amp: 0.25,
+            duration_s: 3.0,
+            sample_rate: 48_000,
+            output_channel: 0,
+            input_channel: 0,
+            status: SplCalibrationCaptureStatus::Idle,
+            engine_result: None,
+            reported_db_spl: None,
+        }
+    }
+}
+
+impl SplCalibrationCaptureState {
+    pub fn apply_engine_result(&mut self, result: SplCalibrationResult) {
+        self.engine_result = Some(result);
+        self.status = SplCalibrationCaptureStatus::Complete;
+    }
+
+    /// `true` once the engine has captured a tone AND the user has
+    /// typed the dBSPL their meter read. Consumers gate the Save /
+    /// Continue action on this.
+    pub fn is_ready(&self) -> bool {
+        matches!(self.status, SplCalibrationCaptureStatus::Complete)
+            && self.engine_result.is_some()
+            && self.reported_db_spl.is_some()
+    }
+
+    /// Derive the final `SplCalibration` once both the engine capture
+    /// and the user-entered meter reading are present.
+    pub fn to_spl_calibration(&self) -> Option<SplCalibration> {
+        let er = self.engine_result.as_ref()?;
+        let reported = self.reported_db_spl?;
+        // Use RMS for the cal anchor because peak is noise-sensitive;
+        // the `peak_sample_level` field on SplCalibration still gets
+        // filled from the engine result for future SPL-level targeting.
+        let level = er.rms_sample_level.max(f32::EPSILON);
+        let spl_offset_db = reported - 20.0 * level.log10();
+        Some(SplCalibration {
+            reported_db_spl: reported,
+            reference_freq_hz: er.reference_freq_hz,
+            peak_sample_level: er.peak_sample_level,
+            spl_offset_db,
+        })
     }
 }
 
@@ -660,7 +789,9 @@ impl RecordingSignalType {
 pub use sotf_audio::signal_recorder::{
     BassAnchorChannelResult, BassAnchorResults,
     ProbeDelayChannelResult as DelayProbeChannelResult, ProbeDelayResults as DelayProbeResults,
+    SplCalibrationResult,
 };
+pub use autoeq::roomeq::SplCalibration;
 
 /// Speaker configuration presets
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Adds a new wizard step before Capture that plays a 1 kHz reference tone while the user reads dBSPL from their external meter. The captured pair `(rms_sample_level, reported_db_spl)` derives `SplCalibration::spl_offset_db`, which GD-Opt v2 uses to target the sweep level deterministically (`sweep_level_db_spl`) so the subwoofer isn't driven into harmonic distortion that contaminates bass phase. See `docs/gd_opt_v2_plan.md` §2.6 and §2.11 Q4.

Engine (sotf-engine 1.0.22 → 1.0.23):
- New `run_spl_calibration(output_channel, sample_rate, reference_freq_hz, amp, duration_s, ...)` returns `SplCalibrationResult { sample_rate, peak_sample_level, rms_sample_level, reference_freq_hz, output_channel }`.
- Reuses the `play_per_channel_and_record_mono` helper (from 1.0.22's dedup) so all device-discovery / cpal logic stays single-source. Calibration-specific logic is just: (a) generate a pure tone, (b) slice a stable analysis window skipping 200 ms of attack/release on each end, (c) compute peak+RMS.
- Input validation rejects non-finite / non-positive freq, too- short duration, amplitude outside (0, 1].

Player (sotf-player):
- `RecordingStep::SplCalibration` inserted between `Config` and `Capture`. `all()`, `label()`, `next()`, `previous()` updated in lockstep — the wizard now has 7 steps.
- New `SplCalibrationCaptureStatus` and `SplCalibrationCaptureState` structs mirror the other capture steps. `to_spl_calibration()` derives the final `autoeq::roomeq::SplCalibration` from `(rms_sample_level, reported_db_spl)`: `spl_offset_db = reported_db_spl − 20·log10(rms_sample_level)`.
- Re-exports `SplCalibrationResult` from the engine and the `SplCalibration` struct from autoeq.

Wizard (app-gpui):
- New `components/recording/spl_calibration.rs` with step renderer
  + Primary Start button + `smol::unblock` spawn using the same pattern as the bass-anchor step. Once the engine returns, the status line shows `peak / rms` and prompts the user to enter the meter reading. The derived `spl_offset_db` appears live when the reading is present.
- `RecordingState.spl_calibration_capture` field added.
- `mod.rs` dispatch + wizard-step id ("spl_calibration") + next- disabled arm ("optional; advance freely") added.
- `capture.rs::save_recordings` now populates `RecordingConfiguration.spl_calibration` via `to_spl_calibration()` at save time.

Wizard (app-tui):
- Prev/next cycles extended with `SplCalibration` between Config and Capture in both directions.
- Step-key dispatch + draw placeholder added; full TUI treatment (meter-reading entry widget) lands in a follow-up.
- Test `recording_step_tab_right_cycles_all_steps` updated for the new 7-step cycle and picks up the previously-missing BassAnchor stop as well.

Verified:
- `cargo check -p sotf-engine -p sotf-player -p sotf-gpui -p sotf-tui --lib` clean
- `cargo test -p sotf-tui --lib` — 213 passed

https://claude.ai/code/session_01HgarmmUx6miDyUyb4McSW4