### PR TITLE
app-gpui: make design tokens rem-based so fonts/spacing/icons scale together

### DIFF
--- a/crates/app-gpui/components/design.rs
+++ b/crates/app-gpui/components/design.rs
@@ -2,14 +2,32 @@
 //!
 //! Call `Ds::from_cx(cx)` once at the top of each render function, then use
 //! `d.pad_x`, `d.gap`, `d.r_md`, `d.text_sm`, etc. in method chains.
+//!
+//! # Rem-based vs pixel-based fields
+//!
+//! Fields that should scale with the user's font-zoom setting are expressed in
+//! `Rems` (they multiply against `window.rem_size`, which is updated by the
+//! `IncreaseFontSize` / `DecreaseFontSize` / `ResetFontSize` actions in
+//! `ui/render.rs`). Corner radii are kept in absolute `Pixels` — scaling radii
+//! with font zoom produces visually "bubbly" zoomed UI, so the convention is
+//! that radii track the design language (Apple HIG / Material 3 / Fluent)
+//! rather than the text scale.
 
-use gpui::{Pixels, px};
+use gpui::{Pixels, Rems, px, rems};
 use gpui_design::DesignExt;
+
+/// GPUI's default root rem size, matching the baseline used when
+/// `window.set_rem_size` has not been adjusted. Design-token pixel values are
+/// divided by this constant to produce rem-relative sizes.
+const BASE_REM_PX: f32 = 16.0;
 
 /// Scale factor for extra-small text (axis ticks, badges) relative to `small_size`.
 const TEXT_XS_SCALE: f32 = 0.85;
 
-/// Pre-computed design system values as `Pixels` for direct use in GPUI method chains.
+/// Pre-computed design system values for direct use in GPUI method chains.
+///
+/// Scalable fields (spacing, text) are `Rems` and respond to font zoom.
+/// Corner radii are `Pixels` and remain constant across zoom levels.
 ///
 /// # Example
 /// ```ignore
@@ -18,67 +36,68 @@ const TEXT_XS_SCALE: f32 = 0.85;
 /// ```
 #[derive(Clone, Copy)]
 pub struct Ds {
-    /// Grid unit (4px) — smallest spacing increment
-    pub grid: Pixels,
-    /// Control horizontal padding (12px)
-    pub pad_x: Pixels,
-    /// Control vertical padding (8px)
-    pub pad_y: Pixels,
-    /// Half vertical padding (4px)
-    pub pad_y_half: Pixels,
-    /// Control gap (8px) — space between sibling controls
-    pub gap: Pixels,
-    /// 1.5× control gap (12px)
-    pub gap_md: Pixels,
-    /// Section gap (16px) — space between sections
-    pub section: Pixels,
-    /// 1.5× section gap (24px)
-    pub section_lg: Pixels,
-    /// 2× section gap (32px)
-    pub section_xl: Pixels,
-    /// Card padding (16px)
-    pub card: Pixels,
-    /// Corner radius: small
+    /// Grid unit (~4px) — smallest spacing increment. Scales with font zoom.
+    pub grid: Rems,
+    /// Control horizontal padding (~12px). Scales with font zoom.
+    pub pad_x: Rems,
+    /// Control vertical padding (~8px). Scales with font zoom.
+    pub pad_y: Rems,
+    /// Half vertical padding (~4px). Scales with font zoom.
+    pub pad_y_half: Rems,
+    /// Control gap (~8px) — space between sibling controls. Scales with font zoom.
+    pub gap: Rems,
+    /// 1.5× control gap (~12px). Scales with font zoom.
+    pub gap_md: Rems,
+    /// Section gap (~16px). Scales with font zoom.
+    pub section: Rems,
+    /// 1.5× section gap (~24px). Scales with font zoom.
+    pub section_lg: Rems,
+    /// 2× section gap (~32px). Scales with font zoom.
+    pub section_xl: Rems,
+    /// Card padding (~16px). Scales with font zoom.
+    pub card: Rems,
+    /// Corner radius: small. Fixed in pixels — does not scale.
     pub r_sm: Pixels,
-    /// Corner radius: medium
+    /// Corner radius: medium. Fixed in pixels — does not scale.
     pub r_md: Pixels,
-    /// Corner radius: large
+    /// Corner radius: large. Fixed in pixels — does not scale.
     pub r_lg: Pixels,
-    /// Corner radius: extra-large
+    /// Corner radius: extra-large. Fixed in pixels — does not scale.
     pub r_xl: Pixels,
-    /// Text size: extra-small (~10px)
-    pub text_xs: Pixels,
-    /// Text size: small (~12px)
-    pub text_sm: Pixels,
-    /// Text size: base (~14px)
-    pub text_base: Pixels,
-    /// Text size: large (~16px)
-    pub text_lg: Pixels,
+    /// Text size: extra-small (~10px). Scales with font zoom.
+    pub text_xs: Rems,
+    /// Text size: small (~12px). Scales with font zoom.
+    pub text_sm: Rems,
+    /// Text size: base (~14px). Scales with font zoom.
+    pub text_base: Rems,
+    /// Text size: large (~16px). Scales with font zoom.
+    pub text_lg: Rems,
 }
 
 impl Ds {
     pub fn from_cx(cx: &gpui::App) -> Self {
         let ds = cx.design();
+        let to_rems = |px_value: f32| rems(px_value / BASE_REM_PX);
         Self {
-            grid: px(ds.spacing.grid_unit),
-            pad_x: px(ds.spacing.control_padding_x),
-            pad_y: px(ds.spacing.control_padding_y),
-            pad_y_half: px(ds.spacing.control_padding_y * 0.5),
-            gap: px(ds.spacing.control_gap),
-            gap_md: px(ds.spacing.control_gap * 1.5),
-            section: px(ds.spacing.section_gap),
-            section_lg: px(ds.spacing.section_gap * 1.5),
-            section_xl: px(ds.spacing.section_gap * 2.0),
-            card: px(ds.spacing.card_padding),
+            grid: to_rems(ds.spacing.grid_unit),
+            pad_x: to_rems(ds.spacing.control_padding_x),
+            pad_y: to_rems(ds.spacing.control_padding_y),
+            pad_y_half: to_rems(ds.spacing.control_padding_y * 0.5),
+            gap: to_rems(ds.spacing.control_gap),
+            gap_md: to_rems(ds.spacing.control_gap * 1.5),
+            section: to_rems(ds.spacing.section_gap),
+            section_lg: to_rems(ds.spacing.section_gap * 1.5),
+            section_xl: to_rems(ds.spacing.section_gap * 2.0),
+            card: to_rems(ds.spacing.card_padding),
             r_sm: px(ds.corners.sm),
             r_md: px(ds.corners.md),
             r_lg: px(ds.corners.lg),
             r_xl: px(ds.corners.xl),
             // 85% of small_size for extra-small labels (axis ticks, badges)
-            text_xs: px(ds.typography.small_size * TEXT_XS_SCALE),
-            text_sm: px(ds.typography.small_size),
-            text_base: px(ds.typography.base_size),
-            text_lg: px(ds.typography.large_size),
+            text_xs: to_rems(ds.typography.small_size * TEXT_XS_SCALE),
+            text_sm: to_rems(ds.typography.small_size),
+            text_base: to_rems(ds.typography.base_size),
+            text_lg: to_rems(ds.typography.large_size),
         }
     }
 }

--- a/crates/app-gpui/components/dialogs/mod.rs
+++ b/crates/app-gpui/components/dialogs/mod.rs
@@ -593,8 +593,8 @@ impl PlayerView {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .w(px(24.0))
-                                .h(px(24.0))
+                                .w(rems(1.5))
+                                .h(rems(1.5))
                                 .rounded(d.r_md)
                                 .hover(move |s| s.bg(Theme::with_opacity(text_color, 0.15)))
                                 .on_mouse_up(

--- a/crates/app-gpui/components/icons/mod.rs
+++ b/crates/app-gpui/components/icons/mod.rs
@@ -120,7 +120,17 @@ pub enum IconSize {
 }
 
 impl IconSize {
-    /// Get the pixel size (for APIs that require Pixels)
+    /// Get the pixel size (for APIs that require Pixels).
+    ///
+    /// Prefer [`IconSize::to_rems`] so sizes scale with `window.rem_size`
+    /// (driven by the `IncreaseFontSize` / `DecreaseFontSize` actions). This
+    /// absolute-pixel variant is retained for the few APIs that require
+    /// `Pixels` and for legacy tests; new call sites should render an
+    /// [`Icon`] or use `.to_rems()` directly.
+    #[deprecated(
+        note = "Use `IconSize::to_rems()` (or the `Icon` component) so icons scale with font zoom. \
+                Raw pixel sizes bypass `window.rem_size` and break zoom consistency."
+    )]
     pub fn px(&self) -> Pixels {
         match self {
             IconSize::Xs => px(12.0),

--- a/crates/app-gpui/tests/config_tests.rs
+++ b/crates/app-gpui/tests/config_tests.rs
@@ -361,6 +361,7 @@ fn test_icon_paths() {
 }
 
 #[test]
+#[allow(deprecated)] // `IconSize::px()` is retained for APIs that require Pixels; this pins its legacy contract.
 fn test_icon_sizes() {
     use gpui::px;
     assert_eq!(IconSize::Xs.px(), px(12.0));
@@ -368,6 +369,21 @@ fn test_icon_sizes() {
     assert_eq!(IconSize::Md.px(), px(20.0));
     assert_eq!(IconSize::Lg.px(), px(24.0));
     assert_eq!(IconSize::Xl.px(), px(32.0));
+}
+
+#[test]
+fn test_icon_sizes_to_rems() {
+    use gpui::rems;
+    // Rem-based sizing is the primary API — it scales with `window.rem_size`
+    // driven by IncreaseFontSize / DecreaseFontSize. Values are chosen so that
+    // at the default 16px rem baseline they match the absolute-pixel contract
+    // above (0.75 rem * 16 = 12px, etc.).
+    assert_eq!(IconSize::Xs.to_rems(), rems(0.75));
+    assert_eq!(IconSize::Sm.to_rems(), rems(1.0));
+    assert_eq!(IconSize::Md.to_rems(), rems(1.25));
+    assert_eq!(IconSize::Lg.to_rems(), rems(1.5));
+    assert_eq!(IconSize::Xl.to_rems(), rems(2.0));
+    assert_eq!(IconSize::Xxl.to_rems(), rems(2.25));
 }
 
 // ============================================================================
@@ -423,6 +439,7 @@ fn test_pagination_4k_window() {
 }
 
 #[test]
+#[allow(deprecated)] // Cross-checks the legacy `px()` contract against `to_rems()` at the base rem size.
 fn test_icon_size_to_rems_matches_px_at_base_rem() {
     let base_rem = 16.0_f32;
     let variants = [


### PR DESCRIPTION
## Summary

Phase 1 of the UX sizing-consistency plan for `app-gpui` (see `/root/.claude/plans/the-size-of-objects-velvety-squirrel.md`).

**Root cause:** `IncreaseFontSize` / `DecreaseFontSize` / `ResetFontSize` actions (`ui/mod.rs:612-645`) update `window.rem_size` via `ui/render.rs:155`, but the `Ds` design-token struct emitted absolute `Pixels`. Result: only icons (which use `rems()`) scaled with font zoom — text and spacing stayed fixed, producing the "giant icons next to tiny labels" disproportion users observed. Hardcoded hit areas (e.g., the 24×24 toast-dismiss button) amplified the issue.

**Fix:**
- `components/design.rs` — scalable `Ds` fields (`pad_x/y`, `pad_y_half`, `gap`, `gap_md`, `section*`, `card`, `grid`, `text_xs/sm/base/lg`) switched from `Pixels` to `Rems`, computed as `px_value / 16.0` so they still track `gpui-design`'s platform rules (Apple HIG / Material 3 / Fluent / Neutral). Corner radii (`r_sm/md/lg/xl`) intentionally remain `Pixels` — scaling radii with font zoom makes the UI look "bubbly", convention is that corners track the design language rather than the text scale.
- `components/icons/mod.rs` — `IconSize::px()` marked `#[deprecated]` steering callers to `to_rems()` / the `Icon` component. No lib callers (only legacy tests), so no warnings fire today but regressions get caught.
- `components/dialogs/mod.rs:595-597` — toast-dismiss hit area `.w(px(24.0)).h(px(24.0))` → `.w(rems(1.5)).h(rems(1.5))` so the click target grows with the `IconSize::Sm` glyph it contains.

Phase 2 (full migration of remaining hardcoded `px(N.0)` call sites across `autoeq/`, `plugins/`, `room_eq/`, `spinorama_eq/`, `settings/`, `recording/`, `home/`, `dialogs/`) will ship in a follow-up PR once Phase 1 is validated in-app.

## Test plan

- [x] `cargo check -p sotf-gpui` — clean
- [x] `cargo clippy -p sotf-gpui` — only 7 pre-existing warnings unrelated to this change
- [x] `cargo test -p sotf-gpui --lib` — 3 passed, 0 failed
- [ ] Manual: `cargo run --bin SotF --release`, then `Cmd++` / `Cmd+-` / `Cmd+0`. Text, spacing, icons, and hit areas should scale together; card/button/modal corner radii should stay visually constant. Exercise Library, AutoEQ, Plugins, Settings, Recording panels to confirm no section regressed.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_