### PR TITLE
app-gpui: Phase 3 — design-token drift guard (CI + pre-commit)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,9 @@ jobs:
           sudo AUTOEQ_DIR="$GITHUB_WORKSPACE" just install-ubuntu-x86
           just post-install-npm
 
+      - name: Check design-token drift (app-gpui)
+        run: python3 scripts/check-design-tokens.py
+
       - name: Build
         run: just build
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,11 @@ repos:
     rev: v0.19.1
     hooks:
       - id: markdownlint-cli2
+  - repo: local
+    hooks:
+      - id: check-design-tokens
+        name: Check design-token drift (app-gpui)
+        entry: python3 scripts/check-design-tokens.py
+        language: system
+        pass_filenames: false
+        files: '^crates/app-gpui/(components|ui)/.*\.rs$'

--- a/crates/app-gpui/CLAUDE.md
+++ b/crates/app-gpui/CLAUDE.md
@@ -39,3 +39,26 @@ Extensive testing: e2e, negative, proptest, component, lifecycle, event_integrat
 ```bash
 cargo run --bin SotF --release
 ```
+
+## Design-token drift guard
+
+Spacing, text size, corner radius, and icon size must flow through the design
+system (`components/design.rs` → `Ds::from_cx(cx)`, or `spacing::*`/`radius::*`
+in `app/constants.rs`). This keeps fonts, icons, and layout scaling together
+when the user invokes the font-zoom actions.
+
+`scripts/check-design-tokens.py` fails CI when raw `px(N.0)` appears in
+`components/` or `ui/` outside the allowlist or without justification. Run it
+locally before committing UI changes:
+
+```bash
+python3 scripts/check-design-tokens.py
+```
+
+Legitimate exceptions:
+- Same-line `// intentional: <reason>` trailing comment.
+- `// intentional: <reason>` comment within 8 lines above (not crossing a
+  blank line).
+- File-level `// intentional-file: <reason>` marker anywhere in the file —
+  use this for chart/meter/table code where pixel dimensions are
+  intrinsically layout-driven.

--- a/crates/app-gpui/components/dialogs/mod.rs
+++ b/crates/app-gpui/components/dialogs/mod.rs
@@ -1301,7 +1301,7 @@ impl PlayerView {
                                     .h_full()
                                     // Calculate width as a fraction of the container
                                     // 400px modal - 48px padding (24px each side) = 352px container
-                                    .w(px(352.0 * (progress_width / 100.0)))
+                                    .w(px(352.0 * (progress_width / 100.0))) // intentional: progress-bar width computed from runtime percentage
                                     .bg(theme.accent)
                                     .rounded_full(),
                             ),

--- a/crates/app-gpui/components/graphs/common.rs
+++ b/crates/app-gpui/components/graphs/common.rs
@@ -1,3 +1,5 @@
+// intentional-file: shared chart-rendering primitives
+
 use crate::components::icons::{Icon, IconName, IconSize};
 use crate::theme::Theme;
 use gpui::Rgba;

--- a/crates/app-gpui/components/headphone_eq/step_1_measurements.rs
+++ b/crates/app-gpui/components/headphone_eq/step_1_measurements.rs
@@ -309,7 +309,7 @@ impl PlayerView {
                                         .flex()
                                         .flex_col()
                                         .gap(d.grid)
-                                        .max_h(px(300.0))
+                                        .max_h(px(300.0)) // intentional: fixed scroll container max-height
                                         .overflow_y_scroll()
                                         .when(suggestions.is_empty() && is_loading, |el| {
                                             el.child(

--- a/crates/app-gpui/components/home/footer.rs
+++ b/crates/app-gpui/components/home/footer.rs
@@ -148,7 +148,7 @@ impl Element for WaveformElement {
                     origin: point(x, center_y - px(bar_height)),
                     size: size(px(BAR_WIDTH - 1.0), px(bar_height * 2.0)),
                 },
-                corner_radii: Corners::all(px(1.0)),
+                corner_radii: Corners::all(px(1.0)), // intentional: 1px paint-math rounding inside Element::paint
                 background: bar_color.into(),
                 border_widths: Edges::default(),
                 border_color: Hsla::transparent_black(),

--- a/crates/app-gpui/components/home/library.rs
+++ b/crates/app-gpui/components/home/library.rs
@@ -1579,7 +1579,7 @@ impl PlayerView {
                     .text_color(theme.text_primary)
                     .child(label.to_string()),
             )
-            .child(div().flex_1().h(px(1.0)).bg(theme.border))
+            .child(div().flex_1().h(px(1.0)).bg(theme.border)) // intentional: 1px hairline divider
             .into_any_element()
     }
 

--- a/crates/app-gpui/components/plugins/common.rs
+++ b/crates/app-gpui/components/plugins/common.rs
@@ -1,5 +1,7 @@
 //! Common utilities for plugin UI components
 
+// intentional-file: chart curve rendering uses pixel-exact widths
+
 use crate::app::AppState;
 use crate::app::constants::spacing;
 use crate::app::state::app::KnobDragState;

--- a/crates/app-gpui/components/plugins/level_meters.rs
+++ b/crates/app-gpui/components/plugins/level_meters.rs
@@ -6,6 +6,8 @@
 //! - Level meter panel rendering (for queue screen)
 //! - App methods for level meter group management (mute/solo/dim)
 
+// intentional-file: pixel-exact meter bars, dividers, and peak-hold markers
+
 use gpui::prelude::*;
 use gpui::*;
 use sotf_audio_player::PluginSettings;

--- a/crates/app-gpui/components/plugins/ticks.rs
+++ b/crates/app-gpui/components/plugins/ticks.rs
@@ -5,6 +5,8 @@
 //! - Quadratic: emphasizes values near the maximum (good for dB scales near 0)
 //! - Logarithmic: true logarithmic spacing
 
+// intentional-file: chart axis tick rendering
+
 use gpui::prelude::*;
 use gpui::*;
 

--- a/crates/app-gpui/components/plugins/ui_eq.rs
+++ b/crates/app-gpui/components/plugins/ui_eq.rs
@@ -5,6 +5,8 @@
 //! - Band controls with color coding
 //! - Interactive editing
 
+// intentional-file: EQ chart with pixel-exact control-point geometry
+
 use super::common::{render_knob_sized, render_midi_badge, render_midi_page_indicator};
 use crate::components::graphs::common::rgba_to_u32;
 use crate::app::AppState;

--- a/crates/app-gpui/components/plugins/ui_gate.rs
+++ b/crates/app-gpui/components/plugins/ui_gate.rs
@@ -12,6 +12,8 @@
 //! |                  | └──────────────────────────────────┘       |                  |
 //! +------------------+--------------------------------------------+------------------+
 
+// intentional-file: gate level meter with pixel-exact threshold marker
+
 use super::common::{
     render_knob, render_section_title, render_toggle, render_vertical_slider_with_ticks,
 };

--- a/crates/app-gpui/components/plugins/ui_layout_renderer.rs
+++ b/crates/app-gpui/components/plugins/ui_layout_renderer.rs
@@ -1094,7 +1094,7 @@ fn render_file_picker(
                         .text_color(text_color)
                         .overflow_hidden()
                         .text_ellipsis()
-                        .max_w(px(120.0))
+                        .max_w(px(120.0)) // intentional: fixed label column max-width
                         .child(display_name.to_string()),
                 ),
         )

--- a/crates/app-gpui/components/plugins/ui_matrix.rs
+++ b/crates/app-gpui/components/plugins/ui_matrix.rs
@@ -6,6 +6,8 @@
 //! - Click to toggle, scroll to adjust
 //! - Preset buttons (Identity, Swap L/R, Mono Mix)
 
+// intentional-file: matrix cell grid driven by named pixel constants
+
 use super::common::ParamSectionStyle;
 use crate::app::AppState;
 use crate::app::types::PluginUpdateType;

--- a/crates/app-gpui/components/plugins/ui_mute_solo.rs
+++ b/crates/app-gpui/components/plugins/ui_mute_solo.rs
@@ -7,6 +7,8 @@
 //! | [Enabled] toggle | [Ch1: M S] [Ch2: M S] [Ch3: M S] ...      |                  |
 //! +------------------+--------------------------------------------+------------------+
 
+// intentional-file: channel strip with embedded level meter geometry
+
 use super::common::{render_section_title, render_toggle};
 use crate::app::AppState;
 use crate::components::design::Ds;

--- a/crates/app-gpui/components/plugins/ui_rack.rs
+++ b/crates/app-gpui/components/plugins/ui_rack.rs
@@ -1,5 +1,7 @@
 //! Plugin screen rendering functions - Professional DAW-style interface
 
+// intentional-file: rack with embedded meters and pixel-exact dividers
+
 use super::actions::ToggleUpmixerConfig;
 use super::level_meters::{db_to_position, render_gradient_meter};
 use super::render_plugin_content;

--- a/crates/app-gpui/components/plugins/ui_rack_detail.rs
+++ b/crates/app-gpui/components/plugins/ui_rack_detail.rs
@@ -2,6 +2,8 @@
 //!
 //! Extracted from ui_rack.rs for maintainability.
 
+// intentional-file: rack detail view with embedded meters and dividers
+
 use super::level_meters::{db_to_position, render_gradient_meter};
 use super::render_plugin_content;
 use super::ui_plugin_shell::{plugin_accent_color as plugin_color, plugin_icon};

--- a/crates/app-gpui/components/plugins/ui_simple.rs
+++ b/crates/app-gpui/components/plugins/ui_simple.rs
@@ -160,7 +160,7 @@ pub fn render_simple_plugin_view(
         )
         .column(
             Column::new("name", "Parameter")
-                .width(px(220.0))
+                .width(px(220.0)) // intentional: fixed plugin-control layout width
                 .sortable(false)
                 .resizable(false)
                 .cell_render(move |row: &ParamRow, row_idx, _, _| {

--- a/crates/app-gpui/components/plugins/ui_spectrum.rs
+++ b/crates/app-gpui/components/plugins/ui_spectrum.rs
@@ -1,5 +1,7 @@
 //! Spectrum Analyzer UI Components
 
+// intentional-file: spectrum analyzer with chart-internal pixel dimensions
+
 use std::panic;
 use std::sync::Arc;
 

--- a/crates/app-gpui/components/room_eq/custom_target_modal.rs
+++ b/crates/app-gpui/components/room_eq/custom_target_modal.rs
@@ -3,6 +3,8 @@
 //! Provides a modal dialog for defining custom target curves via draggable control points.
 //! The curve is defined by control points connected by lines, displayed on a log-frequency graph.
 
+// intentional-file: custom target curve editor with chart-coordinate geometry
+
 use crate::app::AppState;
 use crate::app::types::{CustomTargetCurve, TargetCurveControlPoint};
 use crate::components::design::Ds;

--- a/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
+++ b/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
@@ -6,6 +6,8 @@
 //! measurement stored in `DelayDetectionState`. The user can override
 //! any delay value before advancing to Configure.
 
+// intentional-file: per-channel delay table with fixed column widths
+
 use crate::app::types::room_eq::DelayDetectionStatus;
 use crate::ui::PlayerView;
 use gpui::prelude::*;

--- a/crates/app-gpui/components/spinorama_eq/step_2_configure.rs
+++ b/crates/app-gpui/components/spinorama_eq/step_2_configure.rs
@@ -1139,7 +1139,7 @@ impl PlayerView {
                         )
                         .content(
                             div()
-                                .w(px(700.0))
+                                .w(px(700.0)) // intentional: fixed chart canvas width
                                 .flex()
                                 .flex_col()
                                 .when_some(chart.ok(), |el, c| el.child(c)),

--- a/scripts/check-design-tokens.py
+++ b/scripts/check-design-tokens.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Design-token drift guard for app-gpui.
+
+Fails when a raw `px(N.0)` call appears in GPUI component or UI code outside
+the design-token source-of-truth files, unless an `// intentional: ...`
+comment appears on the same line or within an 8-line look-back window
+(stopping at the first blank line).
+
+Rationale:
+    Phase 1 migrated the `Ds` design tokens to `Rems` so font zoom propagates
+    to spacing and text. Phase 2 migrated remaining hardcoded `px()` call
+    sites across the component tree to those tokens. This script prevents the
+    migrated call sites from silently regressing: any new raw `px(N.0)` must
+    either use a design token (`d.pad_x`, `spacing::MD`, `radius::MD`, ...) or
+    be explicitly marked intentional with a justification comment.
+
+Usage:
+    scripts/check-design-tokens.py
+    scripts/check-design-tokens.py --help
+
+Exit codes:
+    0  no violations
+    1  one or more violations
+    2  usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SEARCH_PATHS: tuple[Path, ...] = (
+    Path("crates/app-gpui/components"),
+    Path("crates/app-gpui/ui"),
+)
+
+# Files exempt from the check. Each is a source-of-truth for design tokens
+# or is system plumbing that must work in absolute pixels.
+ALLOWLIST: frozenset[Path] = frozenset(
+    {
+        Path("crates/app-gpui/components/design.rs"),
+        Path("crates/app-gpui/components/icons/mod.rs"),
+        Path("crates/app-gpui/ui/render.rs"),
+    }
+)
+
+# Path fragments that exempt a file entirely (tests use raw pixels freely).
+EXEMPT_PATH_FRAGMENTS: tuple[str, ...] = ("/tests/",)
+
+PX_RE = re.compile(r"\bpx\(\s*\d")
+INTENTIONAL_RE = re.compile(r"//.*\bintentional\b", re.IGNORECASE)
+FILE_OPT_OUT_RE = re.compile(r"//\s*intentional-file\b", re.IGNORECASE)
+LOOKBACK_LINES = 8
+
+
+def is_exempt(relative_path: Path) -> bool:
+    if relative_path in ALLOWLIST:
+        return True
+    path_str = relative_path.as_posix()
+    return any(fragment in f"/{path_str}" for fragment in EXEMPT_PATH_FRAGMENTS)
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (line_number, line_content) for unjustified `px(N.0)` sites."""
+    violations: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    # File-level opt-out: any `// intentional-file: <reason>` marker in the
+    # file exempts the whole file. Used for chart/meter/table code whose
+    # pixel dimensions are intrinsically layout-driven.
+    if FILE_OPT_OUT_RE.search(text):
+        return violations
+
+    lines = text.splitlines()
+
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        # Skip lines that are themselves comments — `// assert_eq!(... px(12.0))`
+        # in commented-out code shouldn't fail the check.
+        if stripped.startswith("//"):
+            continue
+        if not PX_RE.search(line):
+            continue
+        if INTENTIONAL_RE.search(line):
+            continue
+
+        # Look back up to LOOKBACK_LINES, stopping at the first blank line.
+        justified = False
+        start = max(0, idx - LOOKBACK_LINES)
+        for prev_idx in range(idx - 1, start - 1, -1):
+            prev = lines[prev_idx].rstrip()
+            if prev == "":
+                break
+            if INTENTIONAL_RE.search(prev):
+                justified = True
+                break
+        if not justified:
+            violations.append((idx + 1, line.rstrip()))
+    return violations
+
+
+def collect_violations(repo_root: Path) -> list[tuple[Path, int, str]]:
+    findings: list[tuple[Path, int, str]] = []
+    for search in SEARCH_PATHS:
+        search_abs = repo_root / search
+        if not search_abs.is_dir():
+            continue
+        for rs in sorted(search_abs.rglob("*.rs")):
+            rel = rs.relative_to(repo_root)
+            if is_exempt(rel):
+                continue
+            for line_no, content in check_file(rs):
+                findings.append((rel, line_no, content))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (defaults to current working directory).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    if not (repo_root / "Cargo.toml").is_file():
+        print(f"error: {repo_root} does not look like the sotf repository root", file=sys.stderr)
+        return 2
+
+    findings = collect_violations(repo_root)
+    if not findings:
+        return 0
+
+    for rel, line_no, content in findings:
+        print(f"{rel.as_posix()}:{line_no}: {content.strip()}")
+    print(
+        f"\nerror: {len(findings)} raw px(N.0) call(s) outside the design-token allowlist "
+        "without an `// intentional:` comment.",
+        file=sys.stderr,
+    )
+    print(
+        "Fix by either:\n"
+        "  - migrating to a design token (Ds::from_cx + d.pad_x/d.gap/d.r_md/d.text_sm, "
+        "or spacing::X / radius::X from app/constants.rs)\n"
+        "  - or adding a `// intentional: [reason]` comment on the same line or within "
+        f"{LOOKBACK_LINES} lines above (not crossing a blank line).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 3 of the UI sizing & scaling consistency effort — the regression guard that prevents Phases 1 and 2 from silently unwinding.

Phases 1 and 2 (#156, #157) migrated `app-gpui`'s design tokens to `Rems` and replaced hardcoded `px()` call sites across 34+ files so fonts, icons, and spacing all scale together on font zoom. Without a guard, any future PR can reintroduce `.px(px(12.0))` or `.rounded(px(4.0))` style regressions and silently undo the scaling work. This PR adds that guard.

## What's new

- **`scripts/check-design-tokens.py`** — a self-contained Python script. For every `.rs` file under `crates/app-gpui/components/` and `crates/app-gpui/ui/`, it fails if a raw `px(N.0)` appears without justification.
- **Justification model**:
  - File-level `// intentional-file: <reason>` marker anywhere in the file exempts the whole file (used for chart/meter/table code where pixel dimensions are intrinsically layout-driven).
  - Same-line trailing `// intentional: <reason>` comment on the `px()` line.
  - `// intentional: <reason>` comment within 8 lines above the `px()` line, not separated by a blank line.
- **Allowlist**: `components/design.rs`, `components/icons/mod.rs`, `ui/render.rs` (system plumbing), and everything under `tests/`.
- **Wired into CI** (`.github/workflows/rust.yml`, new step before `just build`).
- **Wired into pre-commit** (`.pre-commit-config.yaml`, local hook scoped to `crates/app-gpui/{components,ui}/**/*.rs`).
- **Doc update** — `crates/app-gpui/CLAUDE.md` explains how to run the check locally and how to use the annotation model.

## Annotations landed

- **13 file-level markers** on plugins chart/meter files, shared graph primitives, and room-EQ tables: `plugins/{ui_eq, ui_spectrum, level_meters, common, ui_mute_solo, ui_matrix, ui_gate, ticks, ui_rack, ui_rack_detail}.rs`, `graphs/common.rs`, `room_eq/{step_2_delay_detection, custom_target_modal}.rs`.
- **7 per-line trailing annotations** on single-site files (`ui_layout_renderer`, `ui_simple`, `home/footer`, `home/library`, `dialogs/mod`, `headphone_eq/step_1_measurements`, `spinorama_eq/step_2_configure`).

No Rust source logic changes — annotations only.

## Test plan

- [x] `python3 scripts/check-design-tokens.py` — exit 0, no output
- [x] Regression simulated: `sed -i '1i\let _x = px(13.0);' crates/app-gpui/components/home/footer.rs` → check correctly rejects with line reference
- [x] After revert → check passes again
- [x] `cargo check -p sotf-gpui` — compile clean (annotation-only changes, no logic impact)

## Follow-ups

None planned. The guard is now in place; future UI work that needs pixel math declares intent explicitly, and reviewers can see it in the diff.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_