### PR TITLE
gpui-ui-kit: fix TextSize::Md silently aliasing text_sm (Typography Phase 1)

### DIFF
--- a/crates/gpui-toolkit/gpui-ui-kit/src/text.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/src/text.rs
@@ -24,6 +24,25 @@ pub enum TextSize {
     Xxl,
 }
 
+impl TextSize {
+    /// Resolve this variant to a rem value matching GPUI / Tailwind conventions.
+    ///
+    /// The values are identical to what GPUI's `text_xs()` / `text_sm()` /
+    /// `text_base()` / `text_lg()` / `text_xl()` / `text_2xl()` helpers apply,
+    /// and scale with `window.set_rem_size()` so font-zoom actions propagate
+    /// uniformly.
+    pub fn to_rems(self) -> Rems {
+        match self {
+            TextSize::Xs => rems(0.75),
+            TextSize::Sm => rems(0.875),
+            TextSize::Md => rems(1.0),
+            TextSize::Lg => rems(1.125),
+            TextSize::Xl => rems(1.25),
+            TextSize::Xxl => rems(1.5),
+        }
+    }
+}
+
 /// Text weight
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TextWeight {
@@ -135,15 +154,11 @@ impl Text {
             .text_color(text_color)
             .font_weight(self.weight.to_font_weight());
 
-        // Apply size
-        text = match self.size {
-            TextSize::Xs => text.text_xs(),
-            TextSize::Sm => text.text_sm(),
-            TextSize::Md => text.text_sm(),
-            TextSize::Lg => text.text_lg(),
-            TextSize::Xl => text.text_xl(),
-            TextSize::Xxl => text.text_2xl(),
-        };
+        // Apply size via the canonical `TextSize::to_rems()` mapping. Keeping a
+        // single source of truth avoids the earlier bug where `Md` silently
+        // aliased `text_sm()` instead of `text_base()`, making default-sized
+        // text one step smaller than intended across the app.
+        text = text.text_size(self.size.to_rems());
 
         if self.truncate {
             text = text.overflow_hidden().whitespace_nowrap();

--- a/crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs
@@ -1,7 +1,32 @@
 //! Text/Typography component tests
 
+use gpui::rems;
 use gpui_ui_kit::text::{Code, Heading, Link, Text, TextSize, TextWeight, code_text_color};
 use gpui_ui_kit::theme::Theme;
+
+#[test]
+fn test_text_size_to_rems_matches_gpui_tailwind_scale() {
+    // These values must match GPUI's `text_xs`/`text_sm`/`text_base`/...
+    // exactly so font-zoom (via `window.set_rem_size`) scales Text uniformly
+    // with everything else. `Md` must resolve to `text_base` (1.0 rem); a prior
+    // bug aliased it to `text_sm` (0.875 rem), making default-sized text one
+    // step smaller than intended. If you change these values, audit every
+    // caller — they're load-bearing for cross-component consistency.
+    assert_eq!(TextSize::Xs.to_rems(), rems(0.75));
+    assert_eq!(TextSize::Sm.to_rems(), rems(0.875));
+    assert_eq!(TextSize::Md.to_rems(), rems(1.0));
+    assert_eq!(TextSize::Lg.to_rems(), rems(1.125));
+    assert_eq!(TextSize::Xl.to_rems(), rems(1.25));
+    assert_eq!(TextSize::Xxl.to_rems(), rems(1.5));
+}
+
+#[test]
+fn test_text_size_default_is_medium() {
+    // Default-sized text should be `Md` → `rems(1.0)` — the base, not one step
+    // smaller. This pairs with the mapping test above.
+    assert_eq!(TextSize::default(), TextSize::Md);
+    assert_eq!(TextSize::default().to_rems(), rems(1.0));
+}
 
 #[test]
 fn test_text_styling() {


### PR DESCRIPTION
## Summary

Typography Phase 1 — fix a one-line bug that has been making default-sized text across `sotf-gpui` appear one step smaller than intended.

## What was wrong

`gpui-ui-kit/src/text.rs:142` mapped `TextSize::Md` to GPUI's `text_sm()` (0.875 rem / 14px at baseline) when it should map to `text_base()` (1.0 rem / 16px). `TextSize::Md` is the `#[default]` variant — the "medium / base" body size in the `Xs/Sm/Md/Lg/Xl/Xxl` scale — so every Text component rendered with `TextSize::Md` silently rendered at the `Sm` size instead.

The bug is load-bearing because it systematically makes labels, body copy, and default-sized chrome elements one step smaller than they should be whenever font-zoom is adjusted.

## What changed

- **`crates/gpui-toolkit/gpui-ui-kit/src/text.rs`** — added `TextSize::to_rems()` returning the canonical rem value per GPUI/Tailwind conventions. `Text::build_with_theme` now routes through it instead of a duplicated match arm, so the mapping has a single source of truth.
- **`crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs`** — two regression tests pinning the `Xs/Sm/Md/Lg/Xl/Xxl → rems` scale and asserting `TextSize::default() == Md` resolves to `rems(1.0)`. Future changes to the mapping force an explicit audit.

## Rem values pinned

| Variant | Rems | Pixels at baseline |
|---------|------|---------------------|
| `Xs`    | `0.75`  | 12 px |
| `Sm`    | `0.875` | 14 px |
| `Md` (default) | `1.0`   | 16 px ← was 14 px (bug) |
| `Lg`    | `1.125` | 18 px |
| `Xl`    | `1.25`  | 20 px |
| `Xxl`   | `1.5`   | 24 px |

## Behavior change / review attention

Any `Text` component rendered with `TextSize::Md` (explicitly or via default) now measures 16 px at 1× zoom instead of 14 px. This affects ~30% of text sites in `sotf-gpui` (sections called out in the pre-PR audit: dialogs/toasts, home/queue headers, room_eq step headers, recording labels, etc.).

**Reviewer should verify** the larger default size looks right in the denser chrome (toast dismiss, recording config, etc.). The alternative — keeping `Md` aliased to `Sm` — just perpetuates the regression that prompted this typography review.

## Test plan

- [x] `cargo check -p gpui-ui-kit --all-targets`
- [x] `cargo check -p sotf-gpui` (downstream compiles)
- [x] `cargo test -p gpui-ui-kit --test component_tests` — 16 passed, 0 failed (12 existing + 2 new + 2 from parallel files)
- [x] `cargo clippy -p gpui-ui-kit --all-targets` — no new warnings in `text.rs`
- [ ] Manual UX smoke test: run `cargo run --bin SotF --release`, visit toast, dialogs, recording, queue headers at 1× zoom and confirm the slightly-larger `Md` default text looks intentional

## Follow-ups

Typography Phase 2 (unify `Ds` ↔ `TextSize` so there's one typography source of truth across `gpui-ui-kit` `Text` and `sotf-gpui`'s `d.text_*`) and Phase 3 (variant consistency audit across equivalent UI roles) will come as separate PRs.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_