### PR TITLE
gpui-ui-kit + app-gpui: semantic Text constructors + typography style guide (Typography Phase 3)

### DIFF
--- a/crates/app-gpui/CLAUDE.md
+++ b/crates/app-gpui/CLAUDE.md
@@ -62,3 +62,52 @@ Legitimate exceptions:
 - File-level `// intentional-file: <reason>` marker anywhere in the file —
   use this for chart/meter/table code where pixel dimensions are
   intrinsically layout-driven.
+
+## Typography conventions
+
+Two typography APIs coexist and (as of Typography Phase 2) resolve to
+identical rem values — but they remain distinct surfaces. Pick the right one
+per role using the table below.
+
+- `gpui_ui_kit::Text::new(content)...` is the preferred API for UI text. It
+  carries theme color semantics (`muted`, `color`) alongside size/weight.
+- `.text_size(d.text_*)` on a raw `div()` is for cases where `Text` isn't
+  appropriate (e.g. inline spans inside charts, computed labels, or elements
+  that need non-text children alongside styled text).
+
+**Role → variant map.** Prefer the semantic `Text::*` constructors
+(`Text::eyebrow`, `Text::section_header`, `Text::body`, `Text::label`,
+`Text::caption`) over rebuilding the same `.size().weight()` chain by hand.
+Each constructor encodes the convention in one place, so changing a role's
+styling later only needs to update one function in `gpui-ui-kit/src/text.rs`.
+
+| Role | Constructor / pattern | Size | Weight | Extras |
+|------|----------------------|------|--------|--------|
+| Eyebrow label (e.g. "RECORDING NAME", "SAVE LOCATION" — small, caps, accent-colored kicker above a card) | `Text::eyebrow(content).color(theme.accent)` | `Xs` (~12 px) | `Bold` | Caller provides UPPERCASE content and the accent color; constructor pins size+weight. |
+| Screen / dialog title | `Heading::h1(content)` or `Text::new(content).size(TextSize::Lg).weight(TextWeight::Bold)` | `Lg` (~18 px) | `Bold` | `text_primary` color. Reserve for the top of a screen or dialog. |
+| Section header (inside a panel, card, or dialog) | `Text::section_header(content)` | `Md` (~16 px) | `Semibold` | `text_primary` color. One level below screen/dialog title. |
+| Body text / descriptions | `Text::body(content)` | `Md` (~16 px) | `Normal` | Default `text_secondary` color. Use for paragraphs, help text on its own row, and anything that should read as normal body copy. |
+| Inline form-field label, table column header | `Text::label(content)` | `Sm` (~14 px) | `Medium` | `text_secondary` color. Smaller than body so the label reads as secondary to its value. |
+| Data value in a table cell or row | `Text::new(content).size(TextSize::Sm)` | `Sm` (~14 px) | `Normal` | Match the paired label size unless the value needs emphasis. |
+| Status / info message (toast, inline alert) | `Text::new(content).size(TextSize::Sm)` | `Sm` (~14 px) | `Normal` or `Medium` | Prominent but not overwhelming; use the theme's semantic color (`theme.error`, `theme.warning`, `theme.success`) not raw accent. |
+| Caption / helper text (field hint, timestamp, unit suffix) | `Text::caption(content)` | `Xs` (~12 px) | `Normal` | `muted(true)` pulls `theme.text_muted`. |
+| Badge content | `Badge::new(content)` (handles its own sizing) | — | — | Don't hand-build; use the `Badge` component. |
+| Chart axis tick, micro-type on a meter, tiny diagnostic readout | `.text_size(d.text_xs)` on a raw `div()` | rems(0.625) (~10 px) | varies | `d.text_xs` is intentionally smaller than `TextSize::Xs`; reserve for chart internals and similar dense micro-type. |
+
+**Rules of thumb**:
+- A `.weight(Bold)` call paired with `.size(TextSize::Xs)` usually means
+  "eyebrow label" — migrate to `Text::eyebrow`. If it's *not* an eyebrow
+  (no caps, no accent color), it's probably a compressed section header
+  that should become `Text::section_header`.
+- `.muted(true)` paired with `.size(TextSize::Xs)` is the caption pattern —
+  migrate to `Text::caption`.
+- The `TextSize::Md` default is real `text_base()` (~16 px) since Typography
+  Phase 1 — don't compensate for the old buggy Md→Sm aliasing by explicitly
+  reaching for `TextSize::Sm` where `Md` is what you mean.
+
+**Changing a convention.** Update the constructor in
+`crates/gpui-toolkit/gpui-ui-kit/src/text.rs` and the pinning tests in
+`crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs` together.
+The tests read the constructor's state via `Text::preset_style()` so any
+change surfaces immediately — audit the corresponding call sites before
+updating the expected values.

--- a/crates/gpui-toolkit/gpui-ui-kit/src/text.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/src/text.rs
@@ -97,6 +97,61 @@ impl Text {
         }
     }
 
+    /// Eyebrow label — small, bold, uppercase-convention accent text used above
+    /// cards and sections (e.g. "RECORDING NAME", "SAVE LOCATION").
+    ///
+    /// Produces `Xs + Bold`. Callers typically pair it with
+    /// `.color(theme.accent)` and pass content in uppercase. Having a single
+    /// constructor prevents the eyebrow pattern from drifting into
+    /// compressed-header territory (where similar `Xs + Bold` usage should
+    /// instead be `section_header`).
+    pub fn eyebrow(content: impl Into<SharedString>) -> Self {
+        Self::new(content)
+            .size(TextSize::Xs)
+            .weight(TextWeight::Bold)
+    }
+
+    /// Section header inside a panel, card, or dialog — the standard
+    /// body-prominence heading one level below a screen/dialog title.
+    ///
+    /// Produces `Md + Semibold`. Use this instead of building the same
+    /// combination by hand so the whole app stays aligned if the convention
+    /// later shifts (e.g. to `Lg`).
+    pub fn section_header(content: impl Into<SharedString>) -> Self {
+        Self::new(content)
+            .size(TextSize::Md)
+            .weight(TextWeight::Semibold)
+    }
+
+    /// Body text — the default paragraph / description size.
+    ///
+    /// Produces `Md + Normal`. Equivalent to `Text::new(..)` today (since
+    /// `Md` is the default size and `Normal` the default weight) but named
+    /// explicitly so intent is legible in call sites.
+    pub fn body(content: impl Into<SharedString>) -> Self {
+        Self::new(content).size(TextSize::Md)
+    }
+
+    /// Inline form-field label or table-column header.
+    ///
+    /// Produces `Sm + Medium`. Smaller than body so labels read as secondary
+    /// to the value they describe; medium weight keeps them distinguishable
+    /// from surrounding body text.
+    pub fn label(content: impl Into<SharedString>) -> Self {
+        Self::new(content)
+            .size(TextSize::Sm)
+            .weight(TextWeight::Medium)
+    }
+
+    /// Caption / helper text — field hints, timestamps, unit suffixes, and
+    /// other tertiary info.
+    ///
+    /// Produces `Xs + Normal + muted`. The muted color comes from
+    /// `theme.text_muted`, so callers don't need to pass a theme.
+    pub fn caption(content: impl Into<SharedString>) -> Self {
+        Self::new(content).size(TextSize::Xs).muted(true)
+    }
+
     /// Set theme
     pub fn with_theme(mut self, theme: Theme) -> Self {
         self.theme = Some(theme);
@@ -131,6 +186,16 @@ impl Text {
     pub fn truncate(mut self, truncate: bool) -> Self {
         self.truncate = truncate;
         self
+    }
+
+    /// Read-only view of the current size / weight / muted flag.
+    ///
+    /// Intended primarily for tests that pin the state produced by the
+    /// semantic constructors (`eyebrow`, `section_header`, `body`, `label`,
+    /// `caption`). Existence of a value-returning accessor avoids collision
+    /// with the `size(...)` / `weight(...)` / `muted(...)` builder setters.
+    pub fn preset_style(&self) -> (TextSize, TextWeight, bool) {
+        (self.size, self.weight, self.muted)
     }
 
     /// Build into element with theme from App context

--- a/crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/tests/components/text_test.rs
@@ -85,3 +85,45 @@ fn test_code_uses_theme_code_text_color() {
         "Code text color should come from theme.code_text, not be hardcoded"
     );
 }
+
+// ----------------------------------------------------------------------------
+// Semantic `Text::*` constructor state tests
+//
+// Pin the role → size/weight/muted mapping so the typography conventions
+// documented in app-gpui/CLAUDE.md can't drift silently. If one of these
+// values changes, every caller migrating to the semantic constructor will
+// shift with it — audit usage before updating the expectations here.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_text_eyebrow_is_xs_bold() {
+    let t = Text::eyebrow("RECORDING NAME");
+    assert_eq!(t.preset_style(), (TextSize::Xs, TextWeight::Bold, false));
+}
+
+#[test]
+fn test_text_section_header_is_md_semibold() {
+    let t = Text::section_header("Playback");
+    assert_eq!(
+        t.preset_style(),
+        (TextSize::Md, TextWeight::Semibold, false)
+    );
+}
+
+#[test]
+fn test_text_body_is_md_normal() {
+    let t = Text::body("Description paragraph.");
+    assert_eq!(t.preset_style(), (TextSize::Md, TextWeight::Normal, false));
+}
+
+#[test]
+fn test_text_label_is_sm_medium() {
+    let t = Text::label("Speaker");
+    assert_eq!(t.preset_style(), (TextSize::Sm, TextWeight::Medium, false));
+}
+
+#[test]
+fn test_text_caption_is_xs_normal_muted() {
+    let t = Text::caption("seconds");
+    assert_eq!(t.preset_style(), (TextSize::Xs, TextWeight::Normal, true));
+}


### PR DESCRIPTION
## Summary

Typography Phase 3 — establish the canonical role → size/weight vocabulary so future typography work is consistent by construction, without doing a mass migration that would corrupt intentional styling.

## Why not a mass migration

A naive sweep of `TextSize::Xs + Bold/Semibold` sites (180 of them across `app-gpui`) would "fix" many compressed headers, but inspection showed a large fraction are intentional **eyebrow labels** — small-caps + bold + accent color, a legitimate design pattern used above cards (e.g. `"RECORDING NAME"`, `"SAVE LOCATION"`). I can't visually distinguish eyebrow from compressed-header programmatically, and no visual-QA is available in this session. So: ship the vocabulary, let future code use it, leave existing sites alone.

## What changed

### `gpui-ui-kit/src/text.rs`

Five semantic `Text::*` constructors encode the role → state mapping:

| Constructor | Size | Weight | Extras | Role |
|-------------|------|--------|--------|------|
| `Text::eyebrow` | `Xs` | `Bold` | caller adds `.color(theme.accent)` + CAPS content | kicker above a card |
| `Text::section_header` | `Md` | `Semibold` | default color | panel/card/dialog heading |
| `Text::body` | `Md` | `Normal` | default color | paragraph / description |
| `Text::label` | `Sm` | `Medium` | default color | form-field / table-column label |
| `Text::caption` | `Xs` | `Normal` | `muted(true)` | field hint / timestamp / unit |

New `Text::preset_style() -> (TextSize, TextWeight, bool)` accessor exposes builder state for tests. Named to avoid collision with the `size(..)` / `weight(..)` / `muted(..)` builder setters.

### `gpui-ui-kit/tests/components/text_test.rs`

Five new tests pin each constructor's state mapping. Changing any constructor now breaks a visible test, forcing explicit audit of callers before the drift lands. Existing `test_text_size_to_rems_matches_gpui_tailwind_scale` and friends from Typography Phases 1–2 stay in place.

### `crates/app-gpui/CLAUDE.md`

New **Typography conventions** section with the full role → variant table, rules of thumb for distinguishing eyebrow vs compressed-header vs caption intent, and guidance for when to reach for `Text::*` vs `.text_size(d.text_*)` on a raw div. Agents and contributors now have one canonical place to look up "what size/weight does this role use".

## Intentional non-goals

- **No call-site migrations.** The 489 `TextSize::*` sites and 295 `d.text_*` sites stay visually unchanged. Migrating to `Text::eyebrow` / `section_header` / etc. is opportunistic — happens when a file is next touched.
- **No new enum, no deprecation of existing surfaces.** `Text::new(..).size(..)` still works; the semantic constructors are a sugar layer on top.

## Test plan

- [x] `cargo check -p gpui-ui-kit` — clean
- [x] `cargo check -p sotf-gpui` — clean (no transitive breakage)
- [x] `cargo clippy -p gpui-ui-kit --tests` — no new warnings on text.rs or text_test.rs
- [x] `cargo test -p gpui-ui-kit --test component_tests text_` — 21 passed (16 pre-existing + 5 new preset pinning tests)
- [x] `python3 scripts/check-design-tokens.py` — drift guard still passes

## Closing out typography work

With this PR, the four-phase typography effort (preceded by Phases 1 and 2 in #159 and #160) is done:

- Phase 1 fixed the `TextSize::Md → text_sm` bug (default text was silently one step smaller than intended).
- Phase 2 unified `Ds::text_*` (app-gpui) with `TextSize::*` (gpui-ui-kit) so same-named sizes render identically.
- Phase 3 (this PR) adds the semantic vocabulary and style guide so future typography work starts from a shared reference.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_