### PR TITLE
app-gpui: migrate 17 files to semantic Text::caption + Text::eyebrow (Typography Phase 4)

### DIFF
--- a/crates/app-gpui/components/dialogs/mod.rs
+++ b/crates/app-gpui/components/dialogs/mod.rs
@@ -71,11 +71,7 @@ impl PlayerView {
                             .into_any_element()
                     })),
             )
-            .footer(
-                Text::new("Press ESC or ? to close")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Press ESC or ? to close"))
     }
 
     pub(crate) fn render_about_dialog(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -130,11 +126,7 @@ impl PlayerView {
                                     .size(TextSize::Xs)
                                     .color(theme.text_secondary),
                             )
-                            .child(
-                                Text::new("© 2026 Spinorama")
-                                    .size(TextSize::Xs)
-                                    .color(theme.text_muted),
-                            ),
+                            .child(Text::caption("© 2026 Spinorama")),
                     )
                     .child(div().w_full().h(px(1.0)).bg(theme.border)) // intentional: 1px hairline divider, no matching token
                     .child(
@@ -187,11 +179,7 @@ impl PlayerView {
                 HStack::new()
                     .width(StackSize::Full)
                     .justify(StackJustify::SpaceBetween)
-                    .child(
-                        Text::new("Press ESC to close")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption("Press ESC to close"))
                     .child(
                         gpui_ui_kit::Button::new("about-close", "Close")
                             .variant(gpui_ui_kit::ButtonVariant::Primary)
@@ -301,11 +289,7 @@ impl PlayerView {
                             )),
                     ),
             )
-            .footer(
-                Text::new("Press ESC or Shift-? to close")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Press ESC or Shift-? to close"))
     }
 
     /// Render modal for empty library prompt shown on startup
@@ -439,11 +423,7 @@ impl PlayerView {
                             ),
                     ),
             )
-            .footer(
-                Text::new("Press ESC to skip")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Press ESC to skip"))
     }
 
     fn render_keybinding_row(
@@ -732,11 +712,7 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("Enter path to APO file:")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption("Enter path to APO file:"))
                     .child(
                         div()
                             .p(d.pad_y)
@@ -750,11 +726,7 @@ impl PlayerView {
                             ),
                     ),
             )
-            .footer(
-                Text::new("Enter: Load file | ESC: Cancel")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Enter: Load file | ESC: Cancel"))
     }
 
     pub(crate) fn render_sofa_file_dialog(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -768,11 +740,7 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("Enter path to SOFA file:")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption("Enter path to SOFA file:"))
                     .child(
                         div()
                             .p(d.pad_y)
@@ -786,11 +754,7 @@ impl PlayerView {
                             ),
                     ),
             )
-            .footer(
-                Text::new("Enter: Load file | ESC: Cancel")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Enter: Load file | ESC: Cancel"))
     }
 
     pub(crate) fn render_save_plugins_dialog(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -807,11 +771,9 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("Enter preset name (or select existing to overwrite):")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption(
+                        "Enter preset name (or select existing to overwrite):",
+                    ))
                     .child(
                         div()
                             .p(d.pad_y)
@@ -823,11 +785,7 @@ impl PlayerView {
                     )
                     // Show existing presets if available
                     .when(!presets.is_empty(), |el| {
-                        el.child(
-                            Text::new("Existing presets (↑/↓ to select):")
-                                .size(TextSize::Xs)
-                                .muted(true),
-                        )
+                        el.child(Text::caption("Existing presets (↑/↓ to select):"))
                         .child(
                             div()
                                 .id("save-plugins-presets-list")
@@ -865,13 +823,9 @@ impl PlayerView {
                         )
                     }),
             )
-            .footer(
-                Text::new(
-                    "Enter: Save | Click/↑/↓: Select preset | Tab: Autocomplete | ESC: Cancel",
-                )
-                .size(TextSize::Xs)
-                .muted(true),
-            )
+            .footer(Text::caption(
+                "Enter: Save | Click/↑/↓: Select preset | Tab: Autocomplete | ESC: Cancel",
+            ))
     }
 
     pub(crate) fn render_load_plugins_dialog(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -888,11 +842,7 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("Enter preset name or select from list:")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption("Enter preset name or select from list:"))
                     .child(
                         div()
                             .p(d.pad_y)
@@ -904,11 +854,7 @@ impl PlayerView {
                     )
                     // Show existing presets
                     .when(!presets.is_empty(), |el| {
-                        el.child(
-                            Text::new("Available presets (↑/↓ to select):")
-                                .size(TextSize::Xs)
-                                .muted(true),
-                        )
+                        el.child(Text::caption("Available presets (↑/↓ to select):"))
                         .child(
                             div()
                                 .id("load-plugins-presets-list")
@@ -951,19 +897,15 @@ impl PlayerView {
                     })
                     .when(presets.is_empty(), |el| {
                         el.child(
-                            div().p(d.card).text_center().child(
-                                Text::new("No presets found. Save a preset first with 's'.")
-                                    .size(TextSize::Xs)
-                                    .muted(true),
-                            ),
+                            div().p(d.card).text_center().child(Text::caption(
+                                "No presets found. Save a preset first with 's'.",
+                            )),
                         )
                     }),
             )
-            .footer(
-                Text::new("Enter: Load | ↑/↓: Select preset | Tab: Autocomplete | ESC: Cancel")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption(
+                "Enter: Load | ↑/↓: Select preset | Tab: Autocomplete | ESC: Cancel",
+            ))
     }
 }
 
@@ -1107,11 +1049,7 @@ impl PlayerView {
                 HStack::new()
                     .width(StackSize::Full)
                     .justify(StackJustify::SpaceBetween)
-                    .child(
-                        Text::new("Press ESC or ? to close")
-                            .size(TextSize::Xs)
-                            .muted(true),
-                    )
+                    .child(Text::caption("Press ESC or ? to close"))
                     .child(
                         gpui_ui_kit::Button::new("shortcuts-close", "Close")
                             .variant(gpui_ui_kit::ButtonVariant::Primary)
@@ -1307,11 +1245,7 @@ impl PlayerView {
                             ),
                     )
                     // Status text
-                    .child(
-                        Text::new(status_text)
-                            .size(TextSize::Xs)
-                            .color(theme.text_muted),
-                    )
+                    .child(Text::caption(status_text))
                     // Buttons
                     .child(
                         HStack::new()

--- a/crates/app-gpui/components/dialogs/tutorial.rs
+++ b/crates/app-gpui/components/dialogs/tutorial.rs
@@ -498,11 +498,7 @@ impl PlayerView {
                             .into_any_element()
                     })),
             )
-            .footer(
-                Text::new("Press ESC or F1 to close")
-                    .size(TextSize::Xs)
-                    .muted(true),
-            )
+            .footer(Text::caption("Press ESC or F1 to close"))
     }
 }
 

--- a/crates/app-gpui/components/graphs/common.rs
+++ b/crates/app-gpui/components/graphs/common.rs
@@ -5,7 +5,7 @@ use crate::theme::Theme;
 use gpui::Rgba;
 use gpui::prelude::*;
 use gpui_px::ChartTheme;
-use gpui_ui_kit::{Text, TextSize};
+use gpui_ui_kit::Text;
 
 /// Create a new Rgba with modified alpha
 fn with_alpha(rgba: Rgba, alpha: f32) -> Rgba {
@@ -39,11 +39,7 @@ pub fn render_empty_state(
         .gap(gpui::px(8.0))
         .py(gpui::px(24.0))
         .child(Icon::new(icon).size(IconSize::Xl).color(theme.text_muted))
-        .child(
-            Text::new(message.to_string())
-                .size(TextSize::Xs)
-                .color(theme.text_muted),
-        )
+        .child(Text::caption(message.to_string()))
         .into_any_element()
 }
 

--- a/crates/app-gpui/components/headphone_eq/step_1_measurements.rs
+++ b/crates/app-gpui/components/headphone_eq/step_1_measurements.rs
@@ -260,24 +260,16 @@ impl PlayerView {
                                                         ),
                                                 )
                                                 .when(is_loading, |hstack| {
-                                                    hstack.child(
-                                                        Text::new("Loading...")
-                                                            .size(TextSize::Xs)
-                                                            .color(theme.text_muted),
-                                                    )
+                                                    hstack.child(Text::caption("Loading..."))
                                                 })
                                                 .when(
                                                     !is_loading
                                                         && available_headphones_count > 0,
                                                     |hstack| {
-                                                        hstack.child(
-                                                            Text::new(format!(
-                                                                "{} headphones",
-                                                                available_headphones_count
-                                                            ))
-                                                            .size(TextSize::Xs)
-                                                            .color(theme.text_muted),
-                                                        )
+                                                        hstack.child(Text::caption(format!(
+                                                            "{} headphones",
+                                                            available_headphones_count
+                                                        )))
                                                     },
                                                 ),
                                         ),
@@ -297,11 +289,10 @@ impl PlayerView {
                                                 .color(theme.text_primary)
                                                 .weight(TextWeight::Semibold),
                                         )
-                                        .child(
-                                            Text::new(format!("({} matches)", suggestions.len()))
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                        ),
+                                        .child(Text::caption(format!(
+                                            "({} matches)",
+                                            suggestions.len()
+                                        ))),
                                 )
                                 .content(
                                     div()
@@ -312,24 +303,16 @@ impl PlayerView {
                                         .max_h(px(300.0)) // intentional: fixed scroll container max-height
                                         .overflow_y_scroll()
                                         .when(suggestions.is_empty() && is_loading, |el| {
-                                            el.child(
-                                                Text::new(
-                                                    "Loading headphones from spinorama.org...",
-                                                )
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                            )
+                                            el.child(Text::caption(
+                                                "Loading headphones from spinorama.org...",
+                                            ))
                                         })
                                         .when(suggestions.is_empty() && !is_loading, |el| {
-                                            el.child(
-                                                Text::new(if search_query.is_empty() {
-                                                    "No headphones loaded. Click Refresh to load."
-                                                } else {
-                                                    "No matching headphones found."
-                                                })
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                            )
+                                            el.child(Text::caption(if search_query.is_empty() {
+                                                "No headphones loaded. Click Refresh to load."
+                                            } else {
+                                                "No matching headphones found."
+                                            }))
                                         })
                                         .children(suggestions.iter().map(|headphone| {
                                             let is_selected =
@@ -389,11 +372,7 @@ impl PlayerView {
                             vstack.child(
                                 HStack::new()
                                     .spacing(StackSpacing::Xs)
-                                    .child(
-                                        Text::new("Downloading measurement...")
-                                            .size(TextSize::Xs)
-                                            .color(theme.text_muted),
-                                    ),
+                                    .child(Text::caption("Downloading measurement...")),
                             )
                         })
                         // Frequency response graph + Next button after download

--- a/crates/app-gpui/components/home/queue.rs
+++ b/crates/app-gpui/components/home/queue.rs
@@ -768,11 +768,7 @@ impl PlayerView {
                         .size(TextSize::Md)
                         .color(theme.text_muted),
                 )
-                .child(
-                    Text::new(translations.queue_select_album)
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                )
+                .child(Text::caption(translations.queue_select_album))
                 .build()
                 .flex_1()
                 .flex()

--- a/crates/app-gpui/components/plugins/ui_ab_compare.rs
+++ b/crates/app-gpui/components/plugins/ui_ab_compare.rs
@@ -93,15 +93,11 @@ fn render_path_section(
                     .weight(TextWeight::Bold)
                     .color(theme.text_primary),
             )
-            .child(
-                Text::new(format!(
-                    "{} plugin{}",
-                    plugins.len(),
-                    if plugins.len() == 1 { "" } else { "s" }
-                ))
-                .size(TextSize::Xs)
-                .color(theme.text_muted),
-            )
+            .child(Text::caption(format!(
+                "{} plugin{}",
+                plugins.len(),
+                if plugins.len() == 1 { "" } else { "s" }
+            )))
             .child(
                 Button::new(SharedString::from(format!("ab-add-{path}")), "+")
                     .aria_label("Add plugin for comparison")
@@ -132,11 +128,7 @@ fn render_path_section(
     // Plugin list
     if plugins.is_empty() {
         section = section.child(
-            div().py(d.pad_y).child(
-                Text::new("Empty (pass-through)")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            ),
+            div().py(d.pad_y).child(Text::caption("Empty (pass-through)")),
         );
     } else {
         let len = plugins.len();

--- a/crates/app-gpui/components/recording/capture.rs
+++ b/crates/app-gpui/components/recording/capture.rs
@@ -230,11 +230,9 @@ impl PlayerView {
 
         if !is_sweep || recording_state.channel_recordings.is_empty() {
             return Card::new()
-                .content(
-                    Text::new("Frequency range configuration is only available for sweep signals")
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                )
+                .content(Text::caption(
+                    "Frequency range configuration is only available for sweep signals",
+                ))
                 .into_any_element();
         }
 
@@ -267,12 +265,7 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("CHANNEL FREQUENCY RANGE")
-                            .size(TextSize::Xs)
-                            .weight(TextWeight::Bold)
-                            .color(theme.accent),
-                    )
+                    .child(Text::eyebrow("CHANNEL FREQUENCY RANGE").color(theme.accent))
                     .children(
                         channel_data
                             .iter()
@@ -464,12 +457,7 @@ impl PlayerView {
             .content(
                 VStack::new()
                     .spacing(StackSpacing::Sm)
-                    .child(
-                        Text::new("CHANNEL METRICS")
-                            .size(TextSize::Xs)
-                            .weight(TextWeight::Bold)
-                            .color(theme.accent),
-                    )
+                    .child(Text::eyebrow("CHANNEL METRICS").color(theme.accent))
                     // Header row
                     .child(
                         HStack::new()
@@ -541,9 +529,7 @@ impl PlayerView {
                             )
                             .child(
                                 div().w(px(80.0)).child( // intentional: metrics-table column width
-                                    Text::new(format!("{:.1} dB", noise_floor))
-                                        .size(TextSize::Xs)
-                                        .color(theme.text_muted),
+                                    Text::caption(format!("{:.1} dB", noise_floor)),
                                 ),
                             )
                             .into_any_element()
@@ -587,12 +573,7 @@ impl PlayerView {
                         .spacing(StackSpacing::Sm)
                         .justify(StackJustify::SpaceBetween)
                         .align(StackAlign::Center)
-                        .child(
-                            Text::new("CHANNEL STATUS")
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Bold)
-                                .color(theme.accent),
-                        )
+                        .child(Text::eyebrow("CHANNEL STATUS").color(theme.accent))
                         .child(
                             HStack::new()
                                 .spacing(StackSpacing::Xs)
@@ -692,13 +673,9 @@ impl PlayerView {
             return VStack::new()
                 .spacing(StackSpacing::Sm)
                 .child(
-                    div().p(d.card).rounded(d.r_md).bg(theme.surface).child(
-                        Text::new(
-                            "No channels configured. Please go back and configure your devices.",
-                        )
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                    ),
+                    div().p(d.card).rounded(d.r_md).bg(theme.surface).child(Text::caption(
+                        "No channels configured. Please go back and configure your devices.",
+                    )),
                 )
                 .into_any_element();
         }

--- a/crates/app-gpui/components/recording/config.rs
+++ b/crates/app-gpui/components/recording/config.rs
@@ -363,13 +363,9 @@ impl PlayerView {
             container = container.child(row);
         }
 
-        container = container.child(
-            Text::new(
-                "Load a microphone calibration file (CSV) to compensate for microphone frequency response",
-            )
-            .size(TextSize::Xs)
-            .color(theme.text_muted),
-        );
+        container = container.child(Text::caption(
+            "Load a microphone calibration file (CSV) to compensate for microphone frequency response",
+        ));
 
         // Add calibration graph when any channel has data
         let cal_entries: Vec<(usize, CalibrationData)> = channel_data
@@ -473,9 +469,9 @@ impl PlayerView {
                     }),
             )
             .child(
-                Text::new("A timestamped subdirectory will be created for each recording session.")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
+                Text::caption(
+                    "A timestamped subdirectory will be created for each recording session.",
+                ),
             )
             .when(!has_directory, |stack| {
                 stack.child(
@@ -621,15 +617,11 @@ impl PlayerView {
                             });
                         }),
                 )
-                .child(
-                    Text::new(if post_s_opt.is_none() {
-                        "(auto: RT60 + 1 s)"
-                    } else {
-                        ""
-                    })
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-                )
+                .child(Text::caption(if post_s_opt.is_none() {
+                    "(auto: RT60 + 1 s)"
+                } else {
+                    ""
+                }))
         };
 
         // Estimated capture-time hint (§2.7 default: ~14 min for 5 channels).
@@ -655,24 +647,16 @@ impl PlayerView {
 
         VStack::new()
             .spacing(StackSpacing::Sm)
-            .child(
-                Text::new(
-                    "Increase bass precision to improve group delay accuracy below 100 Hz. \
-                     Higher settings require longer recordings.",
-                )
-                .size(TextSize::Xs)
-                .color(theme.text_muted),
-            )
+            .child(Text::caption(
+                "Increase bass precision to improve group delay accuracy below 100 Hz. \
+                 Higher settings require longer recordings.",
+            ))
             .child(bass_row)
             .child(pre_row)
             .child(post_row)
-            .child(
-                Text::new(format!(
-                    "Estimated capture time (5 channels, 10 Hz–20 kHz): ~{estimated_min} min"
-                ))
-                .size(TextSize::Xs)
-                .color(theme.text_muted),
-            )
+            .child(Text::caption(format!(
+                "Estimated capture time (5 channels, 10 Hz–20 kHz): ~{estimated_min} min"
+            )))
     }
 
     /// Open directory dialog to select recording output directory
@@ -1199,7 +1183,7 @@ impl PlayerView {
                                     .into_any_element(),
                             )
                             .child(div().w(px(70.0))) // intentional: align with ch-number input column
-                            .child(Text::new("Ch").size(TextSize::Xs).color(theme.text_muted))
+                            .child(Text::caption("Ch"))
                             .child(div().w(px(30.0))) // intentional: spacer before ch number
                             .child({
                                 let view = view.clone();
@@ -1375,9 +1359,7 @@ impl PlayerView {
                             .child(div().w(px(LABEL_WIDTH))) // intentional: indent spacer matches header
                             .child(
                                 div().w(px(CH_LABEL_WIDTH)).child( // intentional: fixed ch-label column
-                                    Text::new(format!("Ch {}:", ch_idx + 1))
-                                        .size(TextSize::Xs)
-                                        .color(theme.text_muted),
+                                    Text::caption(format!("Ch {}:", ch_idx + 1)),
                                 ),
                             )
                             .child(div().w(px(70.0)).child({ // intentional: fixed ch-number input column
@@ -1873,11 +1855,7 @@ impl PlayerView {
                                 HStack::new()
                                     .spacing(StackSpacing::Xs)
                                     .align(StackAlign::Center)
-                                    .child(
-                                        Text::new("Interface")
-                                            .size(TextSize::Xs)
-                                            .color(theme.text_muted),
-                                    )
+                                    .child(Text::caption("Interface"))
                                     .child({
                                         let view = view.clone();
                                         NumberInput::new(SharedString::from(format!(

--- a/crates/app-gpui/components/recording/evaluating.rs
+++ b/crates/app-gpui/components/recording/evaluating.rs
@@ -282,12 +282,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("MAGNITUDE (dB)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("MAGNITUDE (dB)").color(theme.accent))
                 .child(if has_results {
                     self.render_magnitude_chart(&results, smoothing, &theme)
                         .into_any_element()
@@ -311,12 +306,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("PHASE (degrees)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("PHASE (degrees)").color(theme.accent))
                 .child(if has_results {
                     self.render_phase_chart(&results, smoothing, &theme)
                         .into_any_element()
@@ -340,12 +330,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("GROUP DELAY (ms)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("GROUP DELAY (ms)").color(theme.accent))
                 .child(if has_results {
                     self.render_group_delay_chart(&results, smoothing, &theme)
                         .into_any_element()
@@ -368,12 +353,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("IMPULSE RESPONSE")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("IMPULSE RESPONSE").color(theme.accent))
                 .child(if has_results {
                     self.render_impulse_response_chart(&results, &theme)
                         .into_any_element()
@@ -397,12 +377,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("DISTORTION (THD+N %)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("DISTORTION (THD+N %)").color(theme.accent))
                 .child(if has_results {
                     self.render_distortion_chart(&d, &results, smoothing, &theme)
                         .into_any_element()
@@ -426,12 +401,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("RT60 DECAY (ms)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("RT60 DECAY (ms)").color(theme.accent))
                 .child(if has_results {
                     self.render_rt60_chart(&results, smoothing, &theme)
                         .into_any_element()
@@ -455,12 +425,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("CLARITY (C50/C80 dB)")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("CLARITY (C50/C80 dB)").color(theme.accent))
                 .child(if has_results {
                     self.render_clarity_chart(&results, smoothing, &theme)
                         .into_any_element()
@@ -489,12 +454,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("SPECTROGRAM")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("SPECTROGRAM").color(theme.accent))
                 .child(if has_results {
                     self.render_spectrogram_chart(&d, &results, &theme, sample_rate)
                         .into_any_element()
@@ -531,11 +491,7 @@ impl PlayerView {
             .flex()
             .items_center()
             .justify_center()
-            .child(
-                Text::new("Spectrogram not available")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            )
+            .child(Text::caption("Spectrogram not available"))
             .into_any_element()
     }
 
@@ -661,11 +617,9 @@ impl PlayerView {
                     .weight(TextWeight::Semibold)
                     .color(theme.text_secondary),
             )
-            .child(
-                Text::new("Go back to the Capture step to record frequency responses")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            )
+            .child(Text::caption(
+                "Go back to the Capture step to record frequency responses",
+            ))
     }
 
     /// Compute average SPL in the 100 Hz - 10 kHz range.
@@ -928,11 +882,9 @@ impl PlayerView {
                 .flex()
                 .items_center()
                 .justify_center()
-                .child(
-                    Text::new("Distortion data not available (use Sweep signal)")
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                )
+                .child(Text::caption(
+                    "Distortion data not available (use Sweep signal)",
+                ))
                 .into_any_element();
         }
 
@@ -1225,12 +1177,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("RECORDING SUMMARY")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("RECORDING SUMMARY").color(theme.accent))
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Md)

--- a/crates/app-gpui/components/recording/probe.rs
+++ b/crates/app-gpui/components/recording/probe.rs
@@ -275,11 +275,7 @@ impl PlayerView {
                     .theme(table_theme),
             );
             if let Some(wav) = pc.wav_path.clone() {
-                content = content.child(
-                    Text::new(format!("Recording saved to: {}", wav))
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                );
+                content = content.child(Text::caption(format!("Recording saved to: {}", wav)));
             }
             Card::new()
                 .background(theme.surface)

--- a/crates/app-gpui/components/recording/saving.rs
+++ b/crates/app-gpui/components/recording/saving.rs
@@ -133,12 +133,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("RECORDING NAME")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("RECORDING NAME").color(theme.accent))
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Sm)
@@ -176,13 +171,9 @@ impl PlayerView {
                                 ),
                         ),
                 )
-                .child(
-                    Text::new(
-                        "This name will be used for the subdirectory containing your recordings.",
-                    )
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-                ),
+                .child(Text::caption(
+                    "This name will be used for the subdirectory containing your recordings.",
+                )),
         )
     }
 
@@ -206,12 +197,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("SAVE LOCATION")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("SAVE LOCATION").color(theme.accent))
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Sm)
@@ -317,12 +303,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("FILES TO SAVE")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("FILES TO SAVE").color(theme.accent))
                 .child(
                     VStack::new()
                         .spacing(StackSpacing::Xs)
@@ -338,11 +319,7 @@ impl PlayerView {
                                         .weight(TextWeight::Semibold)
                                         .color(theme.text_primary),
                                 )
-                                .child(
-                                    Text::new("- Configuration and measurement data")
-                                        .size(TextSize::Xs)
-                                        .color(theme.text_muted),
-                                ),
+                                .child(Text::caption("- Configuration and measurement data")),
                         )
                         // Per-channel files
                         .children(
@@ -378,14 +355,10 @@ impl PlayerView {
                                                 .size(TextSize::Xs)
                                                 .color(theme.text_primary),
                                             )
-                                            .child(
-                                                Text::new(format!(
-                                                    "- {} recording",
-                                                    rec.channel_name
-                                                ))
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                            )
+                                            .child(Text::caption(format!(
+                                                "- {} recording",
+                                                rec.channel_name
+                                            )))
                                             .into_any_element(),
                                         HStack::new()
                                             .spacing(StackSpacing::Xs)
@@ -403,14 +376,10 @@ impl PlayerView {
                                                 .size(TextSize::Xs)
                                                 .color(theme.text_primary),
                                             )
-                                            .child(
-                                                Text::new(format!(
-                                                    "- {} frequency response",
-                                                    rec.channel_name
-                                                ))
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                            )
+                                            .child(Text::caption(format!(
+                                                "- {} frequency response",
+                                                rec.channel_name
+                                            )))
                                             .into_any_element(),
                                     ]
                                 })
@@ -442,12 +411,7 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("ACTIONS")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
+                .child(Text::eyebrow("ACTIONS").color(theme.accent))
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Sm)
@@ -523,20 +487,11 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("ROOM DIMENSIONS")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
-                .child(
-                    Text::new(
-                        "Width × Depth × Height. Optional, but lets the optimizer auto-tune \
-                         the Schroeder frequency from room volume.",
-                    )
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-                )
+                .child(Text::eyebrow("ROOM DIMENSIONS").color(theme.accent))
+                .child(Text::caption(
+                    "Width × Depth × Height. Optional, but lets the optimizer auto-tune \
+                     the Schroeder frequency from room volume.",
+                ))
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Sm)
@@ -609,20 +564,11 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("SETUP DESCRIPTION")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
-                .child(
-                    Text::new(
-                        "Notes about the listening position, acoustic treatment, \
-                         equipment chain, anything worth remembering next session.",
-                    )
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-                )
+                .child(Text::eyebrow("SETUP DESCRIPTION").color(theme.accent))
+                .child(Text::caption(
+                    "Notes about the listening position, acoustic treatment, \
+                     equipment chain, anything worth remembering next session.",
+                ))
                 .child(
                     div()
                         .w(px(560.0)) // intentional: wide description field width
@@ -701,23 +647,14 @@ impl PlayerView {
         Card::new().content(
             VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("SPEAKERS PER CHANNEL")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Bold)
-                        .color(theme.accent),
-                )
-                .child(
-                    Text::new(if is_loading {
-                        "Loading catalog from spinorama.org…"
-                    } else if catalog.is_empty() {
-                        "Catalog unavailable. Type freely — any label is saved as-is."
-                    } else {
-                        "Type to filter the spinorama.org catalog; click a match to fill in."
-                    })
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-                )
+                .child(Text::eyebrow("SPEAKERS PER CHANNEL").color(theme.accent))
+                .child(Text::caption(if is_loading {
+                    "Loading catalog from spinorama.org…"
+                } else if catalog.is_empty() {
+                    "Catalog unavailable. Type freely — any label is saved as-is."
+                } else {
+                    "Type to filter the spinorama.org catalog; click a match to fill in."
+                }))
                 .children(rows.into_iter().map(|(row, channel_name, current)| {
                     let suggestions = if open_row == Some(row) {
                         filter_speakers(&catalog, &current, 8)

--- a/crates/app-gpui/components/room_eq/render.rs
+++ b/crates/app-gpui/components/room_eq/render.rs
@@ -830,11 +830,7 @@ fn render_filter_plot(
 
     if frequencies.is_empty() || (eq_filters.is_empty() && broadband_filters.is_empty()) {
         return div()
-            .child(
-                Text::new("No filter data available")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            )
+            .child(Text::caption("No filter data available"))
             .into_any_element();
     }
 
@@ -1360,11 +1356,7 @@ fn render_filter_table(
 
     if filters.is_empty() {
         return div()
-            .child(
-                Text::new("No filters")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            )
+            .child(Text::caption("No filters"))
             .into_any_element();
     }
 
@@ -1429,11 +1421,7 @@ fn render_filter_table(
                                 .size(TextSize::Xs)
                                 .color(gain_color),
                         )
-                        .child(
-                            Text::new(format!("Q:{:.1}", f.q))
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        ),
+                        .child(Text::caption(format!("Q:{:.1}", f.q))),
                 )
         }))
         .into_any_element()

--- a/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
+++ b/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
@@ -263,15 +263,11 @@ impl PlayerView {
                                     .size(TextSize::Sm)
                                     .color(theme.text_secondary),
                             )
-                            .child(
-                                Text::new(
-                                    "Run the Probe step in the Recording wizard to \
-                                     capture per-channel delays, or enter values manually \
-                                     after loading a file that contains probe results.",
-                                )
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                            ),
+                            .child(Text::caption(
+                                "Run the Probe step in the Recording wizard to \
+                                 capture per-channel delays, or enter values manually \
+                                 after loading a file that contains probe results.",
+                            )),
                     ),
             );
         }

--- a/crates/app-gpui/components/room_eq/step_3_configure.rs
+++ b/crates/app-gpui/components/room_eq/step_3_configure.rs
@@ -1849,11 +1849,9 @@ impl PlayerView {
         if speaker_configs.is_empty() {
             return VStack::new()
                 .spacing(StackSpacing::Sm)
-                .child(
-                    Text::new("No channels configured. Load measurement data first.")
-                        .size(TextSize::Xs)
-                        .color(theme.text_muted),
-                )
+                .child(Text::caption(
+                    "No channels configured. Load measurement data first.",
+                ))
                 .into_any_element();
         }
 
@@ -1947,21 +1945,9 @@ impl PlayerView {
                 .child(
                     VStack::new()
                         .spacing(StackSpacing::Xs)
-                        .child(
-                            Text::new("Near-field: <1.5m (desktop)")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        )
-                        .child(
-                            Text::new("Mid-field:  1.5–3m (couch)")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        )
-                        .child(
-                            Text::new("Far-field:  >3m (theater)")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        ),
+                        .child(Text::caption("Near-field: <1.5m (desktop)"))
+                        .child(Text::caption("Mid-field:  1.5–3m (couch)"))
+                        .child(Text::caption("Far-field:  >3m (theater)")),
                 )
                 .child(
                     HStack::new().child(
@@ -2020,16 +2006,12 @@ impl PlayerView {
                 .child(
                     VStack::new()
                         .spacing(StackSpacing::Xs)
-                        .child(
-                            Text::new("Flat: minimize frequency response deviation")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        )
-                        .child(
-                            Text::new("EPA: optimize perceived quality (psychoacoustic)")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        ),
+                        .child(Text::caption(
+                            "Flat: minimize frequency response deviation",
+                        ))
+                        .child(Text::caption(
+                            "EPA: optimize perceived quality (psychoacoustic)",
+                        )),
                 ),
         );
 
@@ -2069,16 +2051,8 @@ impl PlayerView {
                 .child(
                     VStack::new()
                         .spacing(StackSpacing::Xs)
-                        .child(
-                            Text::new("IIR: low latency (<5ms)")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        )
-                        .child(
-                            Text::new("Mixed Phase: best quality")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        ),
+                        .child(Text::caption("IIR: low latency (<5ms)"))
+                        .child(Text::caption("Mixed Phase: best quality")),
                 ),
         );
 

--- a/crates/app-gpui/components/room_eq/step_5_review.rs
+++ b/crates/app-gpui/components/room_eq/step_5_review.rs
@@ -321,11 +321,9 @@ impl PlayerView {
                                 .color(theme.text_primary)
                                 .weight(TextWeight::Semibold),
                         )
-                        .content(
-                            Text::new("No optimization results yet. Run optimization first.")
-                                .size(TextSize::Xs)
-                                .color(theme.text_muted),
-                        ),
+                        .content(Text::caption(
+                            "No optimization results yet. Run optimization first.",
+                        )),
                 )
                 .into_any_element();
         }

--- a/crates/app-gpui/components/spinorama_eq/step_1_select.rs
+++ b/crates/app-gpui/components/spinorama_eq/step_1_select.rs
@@ -136,23 +136,15 @@ impl PlayerView {
                                     .when(is_loading, |hstack| {
                                         hstack
                                             .child(Spinner::new().size(SpinnerSize::Sm))
-                                            .child(
-                                                Text::new("Loading...")
-                                                    .size(TextSize::Xs)
-                                                    .color(theme.text_muted),
-                                            )
+                                            .child(Text::caption("Loading..."))
                                     })
                                     .when(
                                         !is_loading && !spinorama.available_speakers.is_empty(),
                                         |hstack| {
-                                            hstack.child(
-                                                Text::new(format!(
-                                                    "{} speakers",
-                                                    spinorama.available_speakers.len()
-                                                ))
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                            )
+                                            hstack.child(Text::caption(format!(
+                                                "{} speakers",
+                                                spinorama.available_speakers.len()
+                                            )))
                                         },
                                     ),
                             ),
@@ -172,11 +164,10 @@ impl PlayerView {
                                     .color(theme.text_primary)
                                     .weight(TextWeight::Semibold),
                             )
-                            .child(
-                                Text::new(format!("({} matches)", suggestions.len()))
-                                    .size(TextSize::Xs)
-                                    .color(theme.text_muted),
-                            ),
+                            .child(Text::caption(format!(
+                                "({} matches)",
+                                suggestions.len()
+                            ))),
                     )
                     .content(
                         div()
@@ -196,23 +187,17 @@ impl PlayerView {
                                         .gap(d.gap)
                                         .py(d.section)
                                         .child(Spinner::new().size(SpinnerSize::Md))
-                                        .child(
-                                            Text::new("Loading speakers from spinorama.org...")
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                        ),
+                                        .child(Text::caption(
+                                            "Loading speakers from spinorama.org...",
+                                        )),
                                 )
                             })
                             .when(suggestions.is_empty() && !is_loading, |el| {
-                                el.child(
-                                    Text::new(if search_query.is_empty() {
-                                        "No speakers loaded. Click Refresh to load."
-                                    } else {
-                                        "No matching speakers found."
-                                    })
-                                    .size(TextSize::Xs)
-                                    .color(theme.text_muted),
-                                )
+                                el.child(Text::caption(if search_query.is_empty() {
+                                    "No speakers loaded. Click Refresh to load."
+                                } else {
+                                    "No matching speakers found."
+                                }))
                             })
                             .children(suggestions.iter().map(|speaker| {
                                 let is_selected = selected_speaker.as_ref() == Some(speaker);
@@ -295,20 +280,12 @@ impl PlayerView {
                                                 .color(theme.text_primary),
                                         )
                                         .when(loading_versions, |vs| {
-                                            vs.child(
-                                                Text::new("Loading versions...")
-                                                    .size(TextSize::Xs)
-                                                    .color(theme.text_muted),
-                                            )
+                                            vs.child(Text::caption("Loading versions..."))
                                         })
                                         .when(
                                             !loading_versions && available_versions.is_empty(),
                                             |vs| {
-                                                vs.child(
-                                                    Text::new("No versions available")
-                                                        .size(TextSize::Xs)
-                                                        .color(theme.text_muted),
-                                                )
+                                                vs.child(Text::caption("No versions available"))
                                             },
                                         )
                                         .when(
@@ -388,11 +365,7 @@ impl PlayerView {
                                 .child(
                                     HStack::new()
                                         .spacing(StackSpacing::Xs)
-                                        .child(
-                                            Text::new("Phase Data:")
-                                                .size(TextSize::Xs)
-                                                .color(theme.text_muted),
-                                        )
+                                        .child(Text::caption("Phase Data:"))
                                         .child(
                                             Text::new(if has_phase_data {
                                                 "Available"
@@ -455,11 +428,7 @@ impl PlayerView {
                                             .size(TextSize::Xs)
                                             .color(theme.error),
                                     )
-                                    .child(
-                                        Text::new(err)
-                                            .size(TextSize::Xs)
-                                            .color(theme.text_muted),
-                                    ),
+                                    .child(Text::caption(err)),
                             )
                             .into_any_element()
                     } else if has_spinorama_curves {
@@ -585,11 +554,9 @@ impl PlayerView {
                                     .color(theme.text_primary)
                                     .weight(TextWeight::Semibold),
                             )
-                            .content(
-                                Text::new("Spinorama data will appear after selecting a speaker with CEA2034 measurement")
-                                    .size(TextSize::Xs)
-                                    .color(theme.text_muted),
-                            )
+                            .content(Text::caption(
+                                "Spinorama data will appear after selecting a speaker with CEA2034 measurement",
+                            ))
                             .into_any_element()
                     },
                 )

--- a/crates/app-gpui/components/spinorama_eq/step_2_configure.rs
+++ b/crates/app-gpui/components/spinorama_eq/step_2_configure.rs
@@ -817,11 +817,9 @@ impl PlayerView {
                     .size(TextSize::Xs)
                     .color(theme.text_secondary),
             )
-            .child(
-                Text::new("Spinorama EQ currently supports PEQ/IIR output in this workflow.")
-                    .size(TextSize::Xs)
-                    .color(theme.text_muted),
-            )
+            .child(Text::caption(
+                "Spinorama EQ currently supports PEQ/IIR output in this workflow.",
+            ))
             .child(
                 Card::new()
                     .background(theme.surface)
@@ -873,11 +871,7 @@ impl PlayerView {
                                     )
                                 }),
                             ))
-                            .child(
-                                Text::new(current_mode.description())
-                                    .size(TextSize::Xs)
-                                    .color(theme.text_muted),
-                            ),
+                            .child(Text::caption(current_mode.description())),
                     ),
             )
             // Target curve selection (only shown when mode is FlatOnPir/Target)
@@ -943,11 +937,7 @@ impl PlayerView {
                                             },
                                         ),
                                     ))
-                                    .child(
-                                        Text::new(current_curve.as_str())
-                                            .size(TextSize::Xs)
-                                            .color(theme.text_muted),
-                                    ),
+                                    .child(Text::caption(current_curve.as_str())),
                             ),
                     )
                 },


### PR DESCRIPTION
## Summary

Follow-up to #161. Migrates app-gpui call sites whose existing state exactly matches one of the new semantic `Text::*` constructors, so the callers can shed the `.size(..).weight(..).color(..)` boilerplate without changing anything visual.

The migration is **state-preserving by construction** — `Text::caption` resolves to `Xs + Normal + text_muted` color (via the muted flag), which is what `.size(Xs).muted(true)` and `.size(Xs).color(theme.text_muted)` already produced. `Text::eyebrow` resolves to `Xs + Bold + <caller color>`, identical to the manual chain it replaces.

The risky migrations — `Text::section_header` (would shift `Md+Bold` / `Sm+Semibold` sites visually) and `Text::label` (would grow `Xs+Semibold` sites to `Sm+Medium`) — are intentionally out of scope, as discussed in #161's PR description. They need per-screen design sign-off.

## What changed

17 files across 4 commits (one per sub-phase, ≤5 files each per CLAUDE.md):

| Sub-phase | Files | Eyebrows | Captions |
|---|---:|---:|---:|
| 4A | `dialogs/mod.rs`, `recording/saving.rs`, `recording/evaluating.rs`, `spinorama_eq/step_1_select.rs`, `room_eq/step_3_configure.rs` | 16 | 43 |
| 4B | `recording/config.rs`, `recording/capture.rs`, `recording/probe.rs`, `headphone_eq/step_1_measurements.rs`, `plugins/ui_ab_compare.rs` | 3 | 20 |
| 4C | `spinorama_eq/step_2_configure.rs`, `room_eq/render.rs`, `room_eq/step_5_review.rs`, `room_eq/step_2_delay_detection.rs`, `home/queue.rs` | 0 | 9 |
| 4D | `graphs/common.rs`, `dialogs/tutorial.rs` | 0 | 2 |
| **Total** | **17** | **19** | **74** |

Net line delta: **+190 / −549 = −359 lines.**

## Intentional skips (examples)

- `ui_ab_compare.rs` L91-94 — `"A"` / `"B"` path-section header at `Xs+Bold+text_primary`. Fits eyebrow by state but not by semantic (not a caps kicker; not accent-colored). Conceptually a compressed section header; proper fix belongs in a future section-header migration pass.
- Conditional-color sites like `.color(if x { theme.success } else { theme.text_muted })` — can't map to a single constructor.
- Anything at `text_secondary`, `text_primary`, `error`, `warning`, or `accent` that isn't one of the defined caption/eyebrow patterns — out of scope.

## Verification

- [x] `cargo check -p sotf-gpui` — clean after every commit
- [x] `cargo clippy -p sotf-gpui` — no new warnings attributable to the migration (one unused `TextSize` import in `graphs/common.rs` got fixed in the same commit that last used it)
- [x] `cargo test -p gpui-ui-kit --test component_tests text_` — all 21 Typography tests still pass (including the 5 pinning tests from #161)
- [x] `python3 scripts/check-design-tokens.py` — drift guard passes
- [x] Zero remaining `Xs + .muted(true)` or `Xs + .color(theme.text_muted)` sites in the 17 migrated files (confirmed by grep)

## Test plan

- [ ] Visual QA: open each migrated screen (about dialog, help modal, shortcuts dialog, tutorial overlay, recording wizard all steps, room EQ all steps, spinorama EQ steps 1+2, headphone EQ step 1, A/B plugin compare, queue empty state, generic chart empty-state) and confirm nothing shifted size/weight/color.

## What's next

With the safe sweep done, the remaining typography work is the design-call batch: decide per-screen whether to standardize on `Text::section_header` (Md+Semibold) and `Text::label` (Sm+Medium) for the sites that would visually change. That's user-driven, not mechanical — separate PR(s) when/if you want to go there.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_