### PR TITLE
app-gpui: autoeq wizard section headers → Text::section_header (Typography Phase 5)

### DIFF
--- a/crates/app-gpui/components/autoeq/render_body_room_eq.rs
+++ b/crates/app-gpui/components/autoeq/render_body_room_eq.rs
@@ -1051,10 +1051,7 @@
                 VStack::new()
                     .spacing(StackSpacing::None)
                     .child(
-                        Text::new("Room Configuration")
-                            .size(TextSize::Sm)
-                            .weight(TextWeight::Semibold)
-                            .color(theme.header_color),
+                        Text::section_header("Room Configuration").color(theme.header_color),
                     )
                     .child(
                         Text::new("Target curve and room correction options")
@@ -1083,10 +1080,7 @@
                 VStack::new()
                     .spacing(StackSpacing::None)
                     .child(
-                        Text::new("Optimiser Configuration")
-                            .size(TextSize::Sm)
-                            .weight(TextWeight::Semibold)
-                            .color(theme.header_color),
+                        Text::section_header("Optimiser Configuration").color(theme.header_color),
                     )
                     .child(
                         Text::new("EQ design and optimisation algorithm settings")

--- a/crates/app-gpui/components/autoeq/render_body_simple.rs
+++ b/crates/app-gpui/components/autoeq/render_body_simple.rs
@@ -90,12 +90,7 @@
             form = form.child(
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new("Preset")
-                            .size(TextSize::Sm)
-                            .weight(TextWeight::Semibold)
-                            .color(theme.header_color),
-                    )
+                    .child(Text::section_header("Preset").color(theme.header_color))
                     .child(
                         Text::new(preset.description)
                             .size(TextSize::Xs)
@@ -185,12 +180,7 @@
         form = form.child(
             VStack::new()
                 .spacing(StackSpacing::None)
-                .child(
-                    Text::new("Optimization Goal")
-                        .size(TextSize::Sm)
-                        .weight(TextWeight::Semibold)
-                        .color(theme.header_color),
-                )
+                .child(Text::section_header("Optimization Goal").color(theme.header_color))
                 .child(
                     Text::new("What should the EQ optimize for?")
                         .size(TextSize::Xs)
@@ -246,12 +236,7 @@
         form = form.child(
             VStack::new()
                 .spacing(StackSpacing::None)
-                .child(
-                    Text::new("Filter Design")
-                        .size(TextSize::Sm)
-                        .weight(TextWeight::Semibold)
-                        .color(theme.header_color),
-                )
+                .child(Text::section_header("Filter Design").color(theme.header_color))
                 .child(
                     Text::new("How many filters and what kind?")
                         .size(TextSize::Xs)
@@ -387,12 +372,7 @@
         form = form.child(
             VStack::new()
                 .spacing(StackSpacing::None)
-                .child(
-                    Text::new("Optimization Quality")
-                        .size(TextSize::Sm)
-                        .weight(TextWeight::Semibold)
-                        .color(theme.header_color),
-                )
+                .child(Text::section_header("Optimization Quality").color(theme.header_color))
                 .child(
                     Text::new("Higher quality takes longer but finds better corrections")
                         .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_algorithm.rs
+++ b/crates/app-gpui/components/autoeq/render_section_algorithm.rs
@@ -7,9 +7,7 @@
         VStack::new()
             .spacing(StackSpacing::None)
             .child(
-                Text::new("Optimisation Algorithm Configuration")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
+                Text::section_header("Optimisation Algorithm Configuration")
                     .color(theme.header_color),
             )
             .child(

--- a/crates/app-gpui/components/autoeq/render_section_capability.rs
+++ b/crates/app-gpui/components/autoeq/render_section_capability.rs
@@ -8,12 +8,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Capability")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Capability").color(theme.header_color))
             .child(
                 Text::new("Select the filter engine for your correction")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_delay.rs
+++ b/crates/app-gpui/components/autoeq/render_section_delay.rs
@@ -6,12 +6,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Delay Correction")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Delay Correction").color(theme.header_color))
             .child(
                 Text::new("Requires a computer or HW interface that supports delay")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_filter_design.rs
+++ b/crates/app-gpui/components/autoeq/render_section_filter_design.rs
@@ -7,12 +7,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Filter Design")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Filter Design").color(theme.header_color))
             .child(
                 Text::new("Configure filter characteristics and frequency ranges")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_goals.rs
+++ b/crates/app-gpui/components/autoeq/render_section_goals.rs
@@ -6,12 +6,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Goals & Configuration")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Goals & Configuration").color(theme.header_color))
             .child(
                 Text::new("Optimization goals and target curve")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_home_cinema.rs
+++ b/crates/app-gpui/components/autoeq/render_section_home_cinema.rs
@@ -6,12 +6,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Home Cinema Specific")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Home Cinema Specific").color(theme.header_color))
             .child(
                 Text::new("Multi-speaker alignment, timbre matching, and seat optimization")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_multi_measurement.rs
+++ b/crates/app-gpui/components/autoeq/render_section_multi_measurement.rs
@@ -7,9 +7,7 @@
         VStack::new()
             .spacing(StackSpacing::None)
             .child(
-                Text::new("Multiple Measurements Per Speaker")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
+                Text::section_header("Multiple Measurements Per Speaker")
                     .color(theme.header_color),
             )
             .child(

--- a/crates/app-gpui/components/autoeq/render_section_optimization_goal.rs
+++ b/crates/app-gpui/components/autoeq/render_section_optimization_goal.rs
@@ -7,12 +7,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Optimisation Goal")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Optimisation Goal").color(theme.header_color))
             .child(
                 Text::new("How the optimizer evaluates correction quality")
                     .size(TextSize::Xs)

--- a/crates/app-gpui/components/autoeq/render_section_target.rs
+++ b/crates/app-gpui/components/autoeq/render_section_target.rs
@@ -8,12 +8,7 @@
     section = section.child(
         VStack::new()
             .spacing(StackSpacing::None)
-            .child(
-                Text::new("Target")
-                    .size(TextSize::Sm)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
-            )
+            .child(Text::section_header("Target").color(theme.header_color))
             .child(
                 Text::new("Listening distance and target slope")
                     .size(TextSize::Xs)


### PR DESCRIPTION
## Summary

First design-call migration after the zero-visual-change sweeps in #161 / #162: all 14 autoeq wizard section headers shift from `Sm+Semibold` to `Md+Semibold` via the `Text::section_header` constructor. User-approved.

```rust
// Before
Text::new(title)
    .size(TextSize::Sm)
    .weight(TextWeight::Semibold)
    .color(theme.header_color)

// After
Text::section_header(title).color(theme.header_color)
```

**Visual impact**: headers grow ~14 px → ~16 px (14% larger). Weight stays Semibold, `theme.header_color` is preserved.

## Why this set first

- **Perfectly uniform pattern**: all 14 sites use the identical chain. No judgment calls mid-migration.
- **Contained screen**: the autoeq wizard. One place to QA.
- **Aligns with the convention**: `Text::section_header` is `Md+Semibold`. Every section header across the app should match this scale; the autoeq wizard was the outlier at `Sm+Semibold`.
- **Preserves `theme.header_color`**: the constructor sets no color, so the existing custom hue (distinct from `text_primary`) remains intact.

## What changed

11 files across 3 sub-phase commits (≤5 files each per CLAUDE.md):

| Sub-phase | Files | Headers |
|---|---:|---:|
| 5A | `render_section_{target,algorithm,goals,optimization_goal,multi_measurement}.rs` | 5 |
| 5B | `render_section_{home_cinema,filter_design,delay,capability}.rs` + `render_body_room_eq.rs` | 6 |
| 5C | `render_body_simple.rs` | 4 |
| **Total** | **11** | **14** (wait — 5+6+4=15 includes 1 double-count; actual = 14) |

Headers migrated: "Target", "Optimisation Algorithm Configuration", "Goals & Configuration", "Optimisation Goal", "Multiple Measurements Per Speaker", "Home Cinema Specific", "Filter Design", "Delay Correction", "Capability", "Room Configuration", "Optimiser Configuration", "Preset", "Optimization Goal", "Optimization Quality".

Net line delta: **+15 / −80 = −65 lines.**

## Verification

- [x] `cargo check -p sotf-gpui` — clean after every commit
- [x] `cargo clippy -p sotf-gpui` — no new warnings
- [x] Zero remaining `Sm+Semibold+header_color` sites in `components/autoeq/` (confirmed by grep)
- [x] `python3 scripts/check-design-tokens.py` — drift guard passes

## Test plan

- [ ] Visual QA: open the autoeq wizard (both Simple and Room-EQ bodies), step through each section, confirm header size bump looks right against the description text immediately below it and against the card bodies they introduce.
- [ ] Check that header text still fits inside cards at the longer section names ("Optimisation Algorithm Configuration", "Multiple Measurements Per Speaker").

## What's next

With the autoeq family done, the remaining Phase-5 candidates are:

- `Md+Bold` → `section_header` (would lose a weight step, Bold → Semibold): 9 sites across `home/queue.rs`, `recording/{evaluating,saving,config,capture}.rs`, `spinorama_eq/step_1_select.rs`, `dialogs/mod.rs`. These look more like screen/dialog titles — probably belong on `Heading::h2` or a separate "title" constructor, not `section_header`.
- `Xs+Semibold` → `Text::label` (would grow ~14 px → ~12 px wait, actually Xs→Sm is 12 px → 14 px): ~50 sites, mostly inline form labels. Bigger visual impact, needs per-screen decision.

Happy to scope either next — or stop here until you've QA'd this one.

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_