### PR TITLE
app-gpui: Md+Bold → Heading::h4 and Xs+Semibold → Text::label sweep (Typography Phase 6)

### DIFF
--- a/crates/app-gpui/components/autoeq/render_body_room_eq.rs
+++ b/crates/app-gpui/components/autoeq/render_body_room_eq.rs
@@ -16,12 +16,7 @@
             let mut options_col = VStack::new().spacing(StackSpacing::Sm);
 
             // --- Target sub-section ---
-            target_col = target_col.child(
-                Text::new("TARGET")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
-            );
+            target_col = target_col.child(Text::eyebrow("TARGET").color(theme.accent));
 
             // Target Tilt
             let mut tilt_toggle = Toggle::new((base_id.clone(), "tilt-enabled"))
@@ -207,12 +202,7 @@
             }
 
             // --- Smoothing sub-section ---
-            options_col = options_col.child(
-                Text::new("SMOOTHING")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
-            );
+            options_col = options_col.child(Text::eyebrow("SMOOTHING").color(theme.accent));
 
             // Psychoacoustic Smoothing
             let mut psycho_toggle = Toggle::new((base_id.clone(), "psychoacoustic"))
@@ -303,10 +293,7 @@
 
             // --- Recommended sub-section ---
             options_col = options_col.child(
-                Text::new("RECOMMENDED")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
+                Text::eyebrow("RECOMMENDED").color(theme.accent),
             );
 
             // Asymmetric Loss
@@ -596,10 +583,7 @@
 
             // --- Delay sub-section ---
             options_col = options_col.child(
-                Text::new("DELAY")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
+                Text::eyebrow("DELAY").color(theme.accent),
             );
 
             // Allow Delay
@@ -657,10 +641,7 @@
 
             // --- Home Cinema sub-section ---
             options_col = options_col.child(
-                Text::new("HOME CINEMA")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
+                Text::eyebrow("HOME CINEMA").color(theme.accent),
             );
 
             // Voice of God
@@ -988,12 +969,8 @@
                     if config.multi_measurement_strategy == "weighted_sum"
                         && !config.multi_measurement_weights.is_empty()
                     {
-                        options_col = options_col.child(
-                            Text::new("Weights")
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Semibold)
-                                .color(theme.text_muted),
-                        );
+                        options_col =
+                            options_col.child(Text::label("Weights").color(theme.text_muted));
                         for (i, &weight) in config.multi_measurement_weights.iter().enumerate() {
                             let label = config
                                 .multi_measurement_labels
@@ -1094,12 +1071,7 @@
             let mut right_col = VStack::new().spacing(StackSpacing::Sm);
 
             // Left column: EQ Design params via shared block
-            left_col = left_col.child(
-                Text::new("EQ DESIGN")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
-            );
+            left_col = left_col.child(Text::eyebrow("EQ DESIGN").color(theme.accent));
             {
                 let eq_design_iir_before_fir = true; // room EQ: IIR shown before FIR
                 let mut block_out = left_col;
@@ -1108,12 +1080,7 @@
             }
 
             // Right column: Optimisation params via shared block
-            right_col = right_col.child(
-                Text::new("OPTIMISATION")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
-            );
+            right_col = right_col.child(Text::eyebrow("OPTIMISATION").color(theme.accent));
             {
                 let mut block_out = right_col;
                 include!("render_block_optimizer.rs");

--- a/crates/app-gpui/components/autoeq/render_body_simple.rs
+++ b/crates/app-gpui/components/autoeq/render_body_simple.rs
@@ -43,10 +43,7 @@
             .justify(StackJustify::SpaceBetween);
 
         detail_row = detail_row.child(
-            Text::new(format!("Mode: {level_label}"))
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
+            Text::label(format!("Mode: {level_label}")).color(theme.header_color),
         );
 
         let mut toggle_btn =

--- a/crates/app-gpui/components/autoeq/render_section_algorithm.rs
+++ b/crates/app-gpui/components/autoeq/render_section_algorithm.rs
@@ -24,12 +24,7 @@
 
     // --- Smoothing ---
     if !hide_smoothing {
-        section = section.child(
-            Text::new("Smoothing")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
-        );
+        section = section.child(Text::label("Smoothing").color(theme.header_color));
 
         // Psychoacoustic toggle (disabled when curve smoothing is on)
         let mut psycho_toggle = Toggle::new((base_id.clone(), "alg-psychoacoustic"))

--- a/crates/app-gpui/components/autoeq/render_section_filter_design.rs
+++ b/crates/app-gpui/components/autoeq/render_section_filter_design.rs
@@ -22,12 +22,7 @@
 
     // --- IIR Subsection ---
     if is_iir {
-        section = section.child(
-            Text::new("IIR Parameters")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
-        );
+        section = section.child(Text::label("IIR Parameters").color(theme.header_color));
 
         // Sample rate + Num filters (side by side)
         let mut sr_input = NumberInput::new((base_id.clone(), "fd-sample-rate"))
@@ -258,12 +253,7 @@
 
     // --- FIR Subsection ---
     if is_fir {
-        section = section.child(
-            Text::new("FIR Parameters")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
-        );
+        section = section.child(Text::label("FIR Parameters").color(theme.header_color));
 
         let mut taps_input = NumberInput::new((base_id.clone(), "fd-fir-taps"))
             .value(config.fir_taps as f64)
@@ -312,12 +302,8 @@
 
     // --- Crossover Subsection ---
     if is_mixed {
-        section = section.child(
-            Text::new("Crossover Configuration")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
-        );
+        section =
+            section.child(Text::label("Crossover Configuration").color(theme.header_color));
 
         let mut xo_freq_input = NumberInput::new((base_id.clone(), "fd-xo-freq"))
             .value(config.mixed_crossover_freq)
@@ -392,12 +378,7 @@
 
     // --- Bass Management Subsection ---
     if !hide_bass_management {
-        section = section.child(
-            Text::new("Bass Management")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.header_color),
-        );
+        section = section.child(Text::label("Bass Management").color(theme.header_color));
 
         // Excursion Protection
         {

--- a/crates/app-gpui/components/autoeq/render_section_multi_measurement.rs
+++ b/crates/app-gpui/components/autoeq/render_section_multi_measurement.rs
@@ -86,10 +86,7 @@
         // Per-measurement weights (for weighted_sum strategy)
         if config.multi_measurement_strategy == "weighted_sum" && !config.multi_measurement_weights.is_empty() {
             section = section.child(
-                Text::new("Measurement Weights")
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.header_color),
+                Text::label("Measurement Weights").color(theme.header_color),
             );
 
             for (i, weight) in config.multi_measurement_weights.iter().enumerate() {

--- a/crates/app-gpui/components/dialogs/mod.rs
+++ b/crates/app-gpui/components/dialogs/mod.rs
@@ -11,7 +11,7 @@ use crate::ui::PlayerView;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_ui_kit::{
-    Badge, BadgeVariant, Dialog, DialogSize, HStack, StackAlign, StackJustify, StackSize,
+    Badge, BadgeVariant, Dialog, DialogSize, HStack, Heading, StackAlign, StackJustify, StackSize,
     StackSpacing, Text, TextSize, TextWeight, ToastVariant, VStack,
 };
 
@@ -229,12 +229,7 @@ impl PlayerView {
             .child(
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new(title.to_string())
-                            .size(TextSize::Xs)
-                            .weight(TextWeight::Semibold)
-                            .color(theme.text_primary),
-                    )
+                    .child(Text::label(title.to_string()).color(theme.text_primary))
                     .child(
                         Text::new(subtitle.to_string())
                             .size(TextSize::Xs)
@@ -1074,12 +1069,7 @@ impl PlayerView {
     ) -> impl IntoElement {
         VStack::new()
             .spacing(StackSpacing::Xs)
-            .child(
-                Text::new(title.to_string())
-                    .size(TextSize::Xs)
-                    .weight(TextWeight::Semibold)
-                    .color(theme.accent),
-            )
+            .child(Text::label(title.to_string()).color(theme.accent))
             .children(shortcuts.iter().map(|(key, desc)| {
                 HStack::new()
                     .spacing(StackSpacing::Sm)
@@ -1214,12 +1204,7 @@ impl PlayerView {
                     .flex_col()
                     .gap(d.section)
                     // Title
-                    .child(
-                        Text::new(scan_type.title())
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold)
-                            .color(theme.text_primary),
-                    )
+                    .child(Heading::h4(scan_type.title()))
                     // Description
                     .child(
                         Text::new(scan_type.description())

--- a/crates/app-gpui/components/home/queue.rs
+++ b/crates/app-gpui/components/home/queue.rs
@@ -8,8 +8,8 @@ use gpui::prelude::*;
 use gpui::*;
 use gpui::{InteractiveElement, Styled};
 use gpui_ui_kit::{
-    Button, CollapseDirection, PaneDivider, PaneDividerTheme, StackSpacing, Text, TextSize,
-    TextWeight, VStack,
+    Button, CollapseDirection, Heading, PaneDivider, PaneDividerTheme, StackSpacing, Text,
+    TextSize, VStack,
 };
 
 use crate::app::types::{MeterDisplayMode, Screen};
@@ -123,17 +123,12 @@ impl PlayerView {
                         .border_r_1()
                         .border_color(theme.border)
                         .child(
-                            Text::new(format!(
+                            div().mb(d.gap).child(Heading::h4(format!(
                                 "{} ({} {})",
                                 translations.queue_title,
                                 state.app.queue_state.len(),
                                 translations.queue_albums
-                            ))
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold)
-                            .color(theme.text_primary)
-                            .build()
-                            .mb(d.gap),
+                            ))),
                         )
                         .child(
                             div()
@@ -595,14 +590,7 @@ impl PlayerView {
                 .flex()
                 .flex_col()
                 .flex_1()
-                .child(
-                    div().mb(d.gap_md).child(
-                        Text::new(translations.queue_now_playing)
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold)
-                            .color(theme.text_primary),
-                    ),
-                )
+                .child(div().mb(d.gap_md).child(Heading::h4(translations.queue_now_playing)))
                 // Top row: Album art (left) + Album info (right)
                 .child(
                     div()

--- a/crates/app-gpui/components/recording/capture.rs
+++ b/crates/app-gpui/components/recording/capture.rs
@@ -9,9 +9,9 @@ use crate::ui::PlayerView;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_ui_kit::{
-    Button, ButtonSize, ButtonVariant, Card, HStack, NumberInput, NumberInputSize, Progress,
-    ProgressSize, ProgressVariant, Select, SelectOption, StackAlign, StackJustify, StackSpacing,
-    Text, TextSize, TextWeight, VStack,
+    Button, ButtonSize, ButtonVariant, Card, HStack, Heading, NumberInput, NumberInputSize,
+    Progress, ProgressSize, ProgressVariant, Select, SelectOption, StackAlign, StackJustify,
+    StackSpacing, Text, TextSize, VStack,
 };
 
 impl PlayerView {
@@ -23,11 +23,7 @@ impl PlayerView {
                 // Header
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new("Signal Recording")
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold),
-                    )
+                    .child(Heading::h4("Signal Recording"))
                     .child(
                         Text::new("Test each channel individually. Signals will play sequentially with a 1-second pause between channels.")
                             .size(TextSize::Xs),
@@ -54,22 +50,14 @@ impl PlayerView {
                     HStack::new()
                         .spacing(StackSpacing::Sm)
                         .align(StackAlign::Center)
-                        .child(
-                            Text::new("Signal Type:")
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Semibold),
-                        )
+                        .child(Text::label("Signal Type:"))
                         .child(self.render_signal_type_dropdown(cx)),
                 )
                 .child(
                     HStack::new()
                         .spacing(StackSpacing::Sm)
                         .align(StackAlign::Center)
-                        .child(
-                            Text::new("Duration:")
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Semibold),
-                        )
+                        .child(Text::label("Duration:"))
                         .child(self.render_duration_dropdown(cx)),
                 )
                 .child(
@@ -278,9 +266,7 @@ impl PlayerView {
                                     .align(StackAlign::Center)
                                     .child(
                                         div().w(px(100.0)).child( // intentional: channel-label column
-                                            Text::new(format!("{}:", name))
-                                                .size(TextSize::Xs)
-                                                .weight(TextWeight::Semibold)
+                                            Text::label(format!("{}:", name))
                                                 .color(theme.text_primary),
                                         ),
                                     )
@@ -465,34 +451,22 @@ impl PlayerView {
                             .align(StackAlign::Center)
                             .child(
                                 div().w(px(100.0)).child( // intentional: metrics-table column width
-                                    Text::new("Channel")
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
-                                        .color(theme.text_secondary),
+                                    Text::label("Channel").color(theme.text_secondary),
                                 ),
                             )
                             .child(
                                 div().w(px(60.0)).child( // intentional: metrics-table column width
-                                    Text::new("Mic In")
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
-                                        .color(theme.text_secondary),
+                                    Text::label("Mic In").color(theme.text_secondary),
                                 ),
                             )
                             .child(
                                 div().w(px(80.0)).child( // intentional: metrics-table column width
-                                    Text::new("Avg SPL")
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
-                                        .color(theme.text_secondary),
+                                    Text::label("Avg SPL").color(theme.text_secondary),
                                 ),
                             )
                             .child(
                                 div().w(px(80.0)).child( // intentional: metrics-table column width
-                                    Text::new("Noise Floor")
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
-                                        .color(theme.text_secondary),
+                                    Text::label("Noise Floor").color(theme.text_secondary),
                                 ),
                             ),
                     )
@@ -760,9 +734,7 @@ impl PlayerView {
                                 .gap(d.gap_md)
                                 .child(
                                     div().w(px(100.0)).child( // intentional: speaker-label column
-                                        Text::new(format!("{}:", speaker_name))
-                                            .size(TextSize::Xs)
-                                            .weight(TextWeight::Semibold)
+                                        Text::label(format!("{}:", speaker_name))
                                             .color(theme.text_primary),
                                     ),
                                 )

--- a/crates/app-gpui/components/recording/config.rs
+++ b/crates/app-gpui/components/recording/config.rs
@@ -11,8 +11,8 @@ use gpui::*;
 use gpui_px::{ScaleType, line};
 use gpui_ui_kit::{
     Accordion, AccordionItem, AccordionMode, Badge, BadgeVariant, Button, ButtonSize,
-    ButtonVariant, HStack, Input, InputSize, NumberInput, NumberInputSize, Select, SelectOption,
-    StackAlign, StackSpacing, Text, TextSize, TextWeight, VStack,
+    ButtonVariant, HStack, Heading, Input, InputSize, NumberInput, NumberInputSize, Select,
+    SelectOption, StackAlign, StackSpacing, Text, TextSize, VStack,
 };
 
 /// Standard channel group definitions
@@ -61,11 +61,7 @@ impl PlayerView {
                 // Header
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new("Audio Device Configuration")
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold),
-                    )
+                    .child(Heading::h4("Audio Device Configuration"))
                     .child(
                         Text::new("Configure your playback and recording devices, set up channel routing, and load microphone calibration.")
                             .size(TextSize::Xs),
@@ -123,11 +119,9 @@ impl PlayerView {
 
     /// Render playback device content for accordion
     fn render_playback_device_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let device_label = VStack::new().spacing(StackSpacing::Xs).child(
-            Text::new("Output Device")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold),
-        );
+        let device_label = VStack::new()
+            .spacing(StackSpacing::Xs)
+            .child(Text::label("Output Device"));
 
         // Sample rate dropdown row
         let sample_rate_row = self
@@ -174,12 +168,9 @@ impl PlayerView {
         };
         let view = cx.weak_entity();
 
-        let device_label = VStack::new().spacing(StackSpacing::Xs).child(
-            Text::new("Input Device")
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold)
-                .color(theme.text_secondary),
-        );
+        let device_label = VStack::new()
+            .spacing(StackSpacing::Xs)
+            .child(Text::label("Input Device").color(theme.text_secondary));
 
         // Sample rate dropdown row
         let sample_rate_row = self
@@ -410,16 +401,11 @@ impl PlayerView {
                             .size(TextSize::Xs)
                             .color(theme.text_secondary),
                     )
-                    .child(
-                        Text::new(display_path)
-                            .size(TextSize::Xs)
-                            .weight(TextWeight::Semibold)
-                            .color(if has_directory {
-                                theme.text_primary
-                            } else {
-                                theme.warning
-                            }),
-                    ),
+                    .child(Text::label(display_path).color(if has_directory {
+                        theme.text_primary
+                    } else {
+                        theme.warning
+                    })),
             )
             .child(
                 HStack::new()

--- a/crates/app-gpui/components/recording/evaluating.rs
+++ b/crates/app-gpui/components/recording/evaluating.rs
@@ -18,8 +18,8 @@ use gpui::prelude::*;
 use gpui::*;
 use gpui_px::ScaleType;
 use gpui_ui_kit::{
-    Card, HStack, Select, SelectOption, StackAlign, StackSpacing, Text, TextSize, TextWeight,
-    VStack,
+    Card, HStack, Heading, Select, SelectOption, StackAlign, StackSpacing, Text, TextSize,
+    TextWeight, VStack,
 };
 use sotf_audio::signal_analysis as dsp;
 
@@ -38,12 +38,7 @@ impl PlayerView {
                 // Header
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new("Evaluate Recordings")
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold)
-                            .color(theme.text_primary),
-                    )
+                    .child(Heading::h4("Evaluate Recordings"))
                     .child(
                         Text::new("Review frequency response, phase, group delay, and impulse response measurements.")
                             .size(TextSize::Xs)
@@ -1207,20 +1202,16 @@ impl PlayerView {
                                         .color(theme.text_secondary),
                                 )
                                 .child(
-                                    Text::new(if recorded_count == total_count {
+                                    Text::label(if recorded_count == total_count {
                                         "All channels recorded"
                                     } else {
                                         "Some channels missing"
                                     })
-                                    .size(TextSize::Xs)
-                                    .weight(TextWeight::Semibold)
-                                    .color(
-                                        if recorded_count == total_count {
-                                            theme.success
-                                        } else {
-                                            theme.warning
-                                        },
-                                    ),
+                                    .color(if recorded_count == total_count {
+                                        theme.success
+                                    } else {
+                                        theme.warning
+                                    }),
                                 ),
                         ),
                 )

--- a/crates/app-gpui/components/recording/probe.rs
+++ b/crates/app-gpui/components/recording/probe.rs
@@ -213,10 +213,7 @@ impl PlayerView {
                             .sortable(false)
                             .resizable(false)
                             .cell_render(move |row: &ProbeResultRow, _, _, _| {
-                                Text::new(row.channel.clone())
-                                    .size(TextSize::Xs)
-                                    .weight(TextWeight::Semibold)
-                                    .color(text_color)
+                                Text::label(row.channel.clone()).color(text_color)
                             }),
                     )
                     .column(
@@ -254,10 +251,7 @@ impl PlayerView {
                                 } else {
                                     error_color
                                 };
-                                Text::new(row.snr_text.clone())
-                                    .size(TextSize::Xs)
-                                    .weight(TextWeight::Semibold)
-                                    .color(color)
+                                Text::label(row.snr_text.clone()).color(color)
                             }),
                     )
                     .column(

--- a/crates/app-gpui/components/recording/saving.rs
+++ b/crates/app-gpui/components/recording/saving.rs
@@ -9,8 +9,8 @@ use crate::ui::PlayerView;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_ui_kit::{
-    Button, ButtonSize, ButtonVariant, Card, HStack, Input, StackAlign, StackSpacing, Text,
-    TextSize, TextWeight, VStack,
+    Button, ButtonSize, ButtonVariant, Card, HStack, Heading, Input, StackAlign, StackSpacing,
+    Text, TextSize, VStack,
 };
 
 /// Filter the available-speakers list to the top matches for a query.
@@ -97,12 +97,7 @@ impl PlayerView {
                 // Header
                 VStack::new()
                     .spacing(StackSpacing::Xs)
-                    .child(
-                        Text::new("Save Recordings")
-                            .size(TextSize::Md)
-                            .weight(TextWeight::Bold)
-                            .color(theme.text_primary),
-                    )
+                    .child(Heading::h4("Save Recordings"))
                     .child(
                         Text::new("Save your recordings and configuration to disk. Files will be saved to the directory you selected during setup.")
                             .size(TextSize::Xs)
@@ -265,12 +260,7 @@ impl PlayerView {
                                 .size(TextSize::Xs)
                                 .color(theme.text_secondary),
                         )
-                        .child(
-                            Text::new(full_path)
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Semibold)
-                                .color(theme.text_primary),
-                        ),
+                        .child(Text::label(full_path).color(theme.text_primary)),
                 ),
         )
     }
@@ -314,9 +304,7 @@ impl PlayerView {
                                 .align(StackAlign::Center)
                                 .child(Text::new("+").size(TextSize::Xs).color(theme.success))
                                 .child(
-                                    Text::new(format!("{}.json", safe_save_name))
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
+                                    Text::label(format!("{}.json", safe_save_name))
                                         .color(theme.text_primary),
                                 )
                                 .child(Text::caption("- Configuration and measurement data")),
@@ -672,10 +660,7 @@ impl PlayerView {
                                 .align(StackAlign::Center)
                                 .child(
                                     div().w(px(80.0)).child( // intentional: channel label column
-                                        Text::new(channel_name.clone())
-                                            .size(TextSize::Xs)
-                                            .weight(TextWeight::Semibold)
-                                            .color(theme.text_primary),
+                                        Text::label(channel_name.clone()).color(theme.text_primary),
                                     ),
                                 )
                                 .child(

--- a/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
+++ b/crates/app-gpui/components/room_eq/step_2_delay_detection.rs
@@ -124,9 +124,7 @@ impl PlayerView {
                         .align(StackAlign::Center)
                         .child(
                             div().w(px(80.0)).child(
-                                Text::new(ch.channel_name.clone())
-                                    .size(TextSize::Xs)
-                                    .weight(TextWeight::Semibold)
+                                Text::label(ch.channel_name.clone())
                                     .color(theme.text_primary),
                             ),
                         )
@@ -146,10 +144,7 @@ impl PlayerView {
                         )
                         .child(
                             div().w(px(80.0)).child(
-                                Text::new(format!("{:+.1}", ch.snr_db))
-                                    .size(TextSize::Xs)
-                                    .weight(TextWeight::Semibold)
-                                    .color(snr_color),
+                                Text::label(format!("{:+.1}", ch.snr_db)).color(snr_color),
                             ),
                         )
                         .child(

--- a/crates/app-gpui/components/room_eq/step_3_configure.rs
+++ b/crates/app-gpui/components/room_eq/step_3_configure.rs
@@ -2223,11 +2223,6 @@ fn simple_dropdown_row(
                 .on_mouse_down(MouseButton::Left, move |_event, _window, cx| {
                     on_click(cx);
                 })
-                .child(
-                    Text::new(current_value)
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Semibold)
-                        .color(value_color),
-                ),
+                .child(Text::label(current_value).color(value_color)),
         )
 }

--- a/crates/app-gpui/components/room_eq/step_4_optimise.rs
+++ b/crates/app-gpui/components/room_eq/step_4_optimise.rs
@@ -149,9 +149,7 @@ impl PlayerView {
                                         .color(theme.text_secondary),
                                 )
                                 .child(
-                                    Text::new("Click Next to review the results.")
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
+                                    Text::label("Click Next to review the results.")
                                         .color(theme.text_secondary),
                                 ),
                         )
@@ -308,22 +306,12 @@ impl PlayerView {
                                         .size(TextSize::Xs)
                                         .color(label_color),
                                 )
-                                .child(
-                                    Text::new(value)
-                                        .size(TextSize::Xs)
-                                        .weight(TextWeight::Semibold)
-                                        .color(value_color),
-                                )
+                                .child(Text::label(value).color(value_color))
                         };
 
                         // Show only enabled toggles as accent-tinted chips —
                         // disabled flags add noise, not signal.
-                        let chip = |label: &'static str| {
-                            Text::new(label)
-                                .size(TextSize::Xs)
-                                .weight(TextWeight::Semibold)
-                                .color(accent)
-                        };
+                        let chip = |label: &'static str| Text::label(label).color(accent);
 
                         // Collapse channel list to a single compact line:
                         // "3: FL, FR, C" rather than "3 (FL, FR, C)".
@@ -766,10 +754,7 @@ impl PlayerView {
                                             .resizable(false)
                                             .cell_render(
                                                 move |pair: &(String, String), _, _, _| {
-                                                    Text::new(pair.1.clone())
-                                                        .size(TextSize::Xs)
-                                                        .weight(TextWeight::Semibold)
-                                                        .color(value_color)
+                                                    Text::label(pair.1.clone()).color(value_color)
                                                 },
                                             ),
                                     )

--- a/crates/app-gpui/components/room_eq/step_6_export.rs
+++ b/crates/app-gpui/components/room_eq/step_6_export.rs
@@ -151,9 +151,7 @@ impl PlayerView {
                                             }),
                                         )
                                         .child(
-                                            Text::new(format!("{} (.{})", format_name, format_ext))
-                                                .size(TextSize::Xs)
-                                                .weight(TextWeight::Semibold)
+                                            Text::label(format!("{} (.{})", format_name, format_ext))
                                                 .color(theme.text_primary),
                                         ),
                                 )

--- a/crates/app-gpui/components/settings/audio_device.rs
+++ b/crates/app-gpui/components/settings/audio_device.rs
@@ -8,9 +8,7 @@ use crate::components::design::Ds;
 use crate::ui::PlayerView;
 use gpui::prelude::*;
 use gpui::*;
-use gpui_ui_kit::{
-    Badge, BadgeVariant, HStack, StackAlign, StackSpacing, Text, TextSize, TextWeight, VStack,
-};
+use gpui_ui_kit::{Badge, BadgeVariant, HStack, StackAlign, StackSpacing, Text, VStack};
 #[cfg(all(target_os = "macos", feature = "hal"))]
 use gpui_ui_kit::{ButtonSet, ButtonSetOption, Select, SelectOption};
 
@@ -35,11 +33,7 @@ impl PlayerView {
             let theme_for_source = theme.clone();
 
             content = content
-                .child(
-                    Text::new("Audio Source")
-                        .size(TextSize::Xs)
-                        .weight(TextWeight::Semibold),
-                )
+                .child(Text::label("Audio Source"))
                 .child({
                     let state_clone = state_entity.clone();
                     let selected = if is_hal_mode { "hal" } else { "file" };
@@ -102,11 +96,7 @@ impl PlayerView {
                     .collect();
 
                 content = content
-                    .child(
-                        Text::new("HAL Configuration")
-                            .size(TextSize::Xs)
-                            .weight(TextWeight::Semibold),
-                    )
+                    .child(Text::label("HAL Configuration"))
                     .child(
                         HStack::new()
                             .spacing(StackSpacing::Md)
@@ -235,11 +225,7 @@ impl PlayerView {
             }
         }
 
-        content = content.child(
-            Text::new(translations.devices_title)
-                .size(TextSize::Xs)
-                .weight(TextWeight::Semibold),
-        );
+        content = content.child(Text::label(translations.devices_title));
 
         content.child(
             // Grid layout with 2 equal-width columns
@@ -307,16 +293,11 @@ impl PlayerView {
                                     .child(
                                         VStack::new()
                                             .spacing(StackSpacing::Xs)
-                                            .child(
-                                                Text::new(device_name)
-                                                    .size(TextSize::Xs)
-                                                    .weight(TextWeight::Semibold)
-                                                    .color(if is_selected {
-                                                        theme.text_on_accent
-                                                    } else {
-                                                        theme.text_primary
-                                                    }),
-                                            )
+                                            .child(Text::label(device_name).color(if is_selected {
+                                                theme.text_on_accent
+                                            } else {
+                                                theme.text_primary
+                                            }))
                                             .child(
                                                 HStack::new()
                                                     .spacing(StackSpacing::Sm)

--- a/crates/app-gpui/components/spinorama_eq/step_1_select.rs
+++ b/crates/app-gpui/components/spinorama_eq/step_1_select.rs
@@ -274,10 +274,7 @@ impl PlayerView {
                                     VStack::new()
                                         .spacing(StackSpacing::Xs)
                                         .child(
-                                            Text::new("Origin / Version")
-                                                .size(TextSize::Xs)
-                                                .weight(TextWeight::Semibold)
-                                                .color(theme.text_primary),
+                                            Text::label("Origin / Version").color(theme.text_primary),
                                         )
                                         .when(loading_versions, |vs| {
                                             vs.child(Text::caption("Loading versions..."))


### PR DESCRIPTION
## Summary

Combined migration of the remaining two Phase-5/6 cohorts, user-approved (`do 1 and 2. consistency is important, i will correct one by one later`):

1. **`Md+Bold` screen/dialog/step titles → `Heading::h4`**. `Heading::h4` renders at `rems(1.0) = text_base` with `BOLD` weight and `text_primary` color — identical output to the migrated sites (with one unification caveat below).

2. **`Xs+Semibold` form labels / table cells / value displays → `Text::label`**. Visible change: `Xs → Sm` (12 px → 14 px, ~17% larger), `Semibold → Medium` (one step lighter). Caller colors preserved.

## Smart-migration exception

Noticed during 6B that `render_body_room_eq.rs` has 7 sites with the pattern `Xs + Semibold + accent + ALL-CAPS content` (TARGET, SMOOTHING, RECOMMENDED, DELAY, HOME CINEMA, EQ DESIGN, OPTIMISATION). These are true kicker labels, not form labels — migrating them to `Text::label` would grow them to Sm+Medium and break the visual hierarchy inside the card. Migrated them to `Text::eyebrow` instead (size stays Xs, weight goes Semibold → Bold, still looks like a kicker).

## Intentional skips

- **`recording/evaluating.rs:1195`** — `format!("{} / {}", recorded_count, total_count)` at Md+Bold. A numeric value display, not a header.
- **`spinorama_eq/step_1_select.rs`** selected-speaker accent label — value emphasis, not header.
- **`autoeq/render_section_{target,optimization_goal,capability}.rs`** — 3 radio-button-style selection indicators using `.weight(if is_selected { Semibold } else { Normal })`. Migrating to `Text::label` would hardcode weight=Medium and destroy the selected/unselected visual distinction. Left as-is.

## Color unification (visible change, flagged)

Two step titles — `recording/config.rs` ("Audio Device Configuration") and `recording/capture.rs` ("Signal Recording") — were using Text's `text_secondary` default instead of explicit `text_primary` like their sibling step titles. Almost certainly an oversight. Migrating to `Heading::h4` unifies them at `text_primary` (brighter). Easy per-site revert if you want the softer look back.

## What changed

18 files (17 migrated + 1 intentionally-skipped family) across 5 sub-phase commits:

| Sub-phase | Files | Md+Bold | Xs+Semibold | Net diff |
|---|---:|---:|---:|---:|
| 6A | dialogs/mod.rs, home/queue.rs, recording/{config,evaluating,capture}.rs | 5 | 14 | −78 |
| 6B | recording/saving.rs, autoeq/{body_room_eq, body_simple, section_filter_design, section_algorithm} | 1 | 7 eyebrows + 8 labels | −75 |
| 6C | autoeq/section_multi_measurement, recording/probe.rs | 0 | 3 | −9 |
| 6D | room_eq/step_{2_delay_detection, 3_configure, 4_optimise, 6_export}, settings/audio_device.rs | 0 | ~13 | −46 |
| 6E | spinorama_eq/step_1_select.rs | 0 | 1 | −3 |
| **Total** | **18** | **6** | **46** | **≈ −211 lines** |

## Verification

- [x] `cargo check -p sotf-gpui` — clean after every commit
- [x] `cargo clippy -p sotf-gpui` — no new warnings; dropped now-unused `TextWeight` imports in 4 files and `TextSize` import in `settings/audio_device.rs`
- [x] `cargo test -p gpui-ui-kit --test component_tests text_` — all 21 Typography tests pass
- [x] `python3 scripts/check-design-tokens.py` — drift guard passes
- [x] Only 3 `Xs+Semibold` sites remain in `components/autoeq/` — the deliberately-skipped dynamic-weight selection indicators (confirmed by grep)

## Test plan

- [ ] Visual QA (user will step through per sub-phase):
  - Dialogs: scan progress modal, shortcuts dialog, about dialog external links, help modal
  - Queue screen: header "Queue (N albums)", "Now Playing" label
  - Recording wizard: all 4 step titles, config/capture/saving/evaluating body labels
  - Autoeq wizard: Simple body mode hint, all caps eyebrow labels inside Room EQ body, sub-section labels in filter_design/algorithm/multi_measurement, preset description
  - Room EQ wizard: delay-detection table, config-step current value, optimise step summary/status/chips/full-params table, export format options
  - Settings: audio source/HAL config/devices title/device list labels
  - Spinorama EQ: "Origin / Version" selector label

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_