### PR TITLE
gpui-ui-kit: WCAG AA theme contrast + IconButton rem migration (A11y Phase A1+A2)

### DIFF
--- a/crates/gpui-toolkit/gpui-ui-kit/src/icon_button.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/src/icon_button.rs
@@ -47,34 +47,44 @@ pub struct IconButtonTheme {
     pub border: Rgba,
 }
 
-/// IconButton size variants
+/// IconButton size variants. Sizes are returned as `Rems` so the click
+/// target scales with `window.set_rem_size` (font zoom). The `Sm`, `Md`,
+/// `Lg`, and `Xl` variants all meet the WCAG 2.5.8 24×24 minimum target
+/// size at 1× zoom; `Xs` (1.0 rem ≈ 16 px) is intentionally below the
+/// floor and reserved for dense chrome / chart-internal use where the
+/// WCAG target rule is informational at small viewports. Prefer `Sm`
+/// (or `Md`) anywhere a user can reasonably hit the button with a mouse
+/// or touch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IconButtonSize {
-    /// Extra small (16px)
+    /// Extra small (1.0 rem ≈ 16 px) — dense chrome / chart internals.
+    /// Below the WCAG 24×24 floor; do not use for primary controls.
     Xs,
-    /// Small (20px)
+    /// Small (1.5 rem ≈ 24 px) — meets the WCAG floor.
     Sm,
-    /// Medium (24px, default)
+    /// Medium (1.5 rem ≈ 24 px, default) — meets the WCAG floor.
     #[default]
     Md,
-    /// Large (32px)
+    /// Large (2.0 rem ≈ 32 px).
     Lg,
-    /// Extra large (48px)
+    /// Extra large (3.0 rem ≈ 48 px).
     Xl,
-    /// Custom size in pixels
+    /// Custom size, expressed in rems × 16 (i.e. logical px at 1× zoom).
     Custom(u32),
 }
 
 impl IconButtonSize {
-    /// Get the size in pixels
-    pub fn size(&self) -> Pixels {
+    /// Get the click-target size in rems. The default GPUI rem is 16 px,
+    /// so the table maps to 16 / 24 / 24 / 32 / 48 logical px at 1× zoom
+    /// and scales linearly with font zoom.
+    pub fn size(&self) -> Rems {
         match self {
-            IconButtonSize::Xs => px(16.0),
-            IconButtonSize::Sm => px(20.0),
-            IconButtonSize::Md => px(24.0),
-            IconButtonSize::Lg => px(32.0),
-            IconButtonSize::Xl => px(48.0),
-            IconButtonSize::Custom(size) => px(*size as f32),
+            IconButtonSize::Xs => rems(1.0),
+            IconButtonSize::Sm => rems(1.5),
+            IconButtonSize::Md => rems(1.5),
+            IconButtonSize::Lg => rems(2.0),
+            IconButtonSize::Xl => rems(3.0),
+            IconButtonSize::Custom(size) => rems(*size as f32 / 16.0),
         }
     }
 }

--- a/crates/gpui-toolkit/gpui-ui-kit/src/theme.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/src/theme.rs
@@ -192,7 +192,7 @@ impl Theme {
             // Text
             text_primary: rgb(0xffffff),
             text_secondary: rgb(0xcccccc),
-            text_muted: rgb(0x888888),
+            text_muted: rgb(0x9c9c9c),
             text_on_accent: rgb(0xffffff),
             icon_on_accent: rgb(0x1e1e1e),
             // Accent
@@ -202,7 +202,7 @@ impl Theme {
             // Semantic
             success: rgb(0x22c55e),
             warning: rgb(0xf59e0b),
-            error: rgb(0xef4444),
+            error: rgb(0xf87171),
             info: rgb(0x3b82f6),
             // Border
             border: rgb(0x3a3a3a),
@@ -244,7 +244,7 @@ impl Theme {
             // Text
             text_primary: rgb(0x1a1a1a),
             text_secondary: rgb(0x4a4a4a),
-            text_muted: rgb(0x888888),
+            text_muted: rgb(0x666666),
             text_on_accent: rgb(0xffffff),
             icon_on_accent: rgb(0x1a1a1a),
             // Accent
@@ -252,10 +252,10 @@ impl Theme {
             accent_hover: rgb(0x0055aa),
             accent_muted: rgba(0x0066cc22),
             // Semantic
-            success: rgb(0x16a34a),
-            warning: rgb(0xd97706),
-            error: rgb(0xdc2626),
-            info: rgb(0x2563eb),
+            success: rgb(0x15803d),
+            warning: rgb(0xb45309),
+            error: rgb(0xb91c1c),
+            info: rgb(0x1d4ed8),
             // Border
             border: rgb(0xd4d4d4),
             border_hover: rgb(0xaaaaaa),
@@ -296,8 +296,8 @@ impl Theme {
             // Text
             text_primary: rgb(0xc9d1d9),
             text_secondary: rgb(0x8b949e),
-            text_muted: rgb(0x6e7681),
-            text_on_accent: rgb(0xffffff),
+            text_muted: rgb(0x8b949e),
+            text_on_accent: rgb(0x0d1117),
             icon_on_accent: rgb(0x0d1117),
             // Accent
             accent: rgb(0x58a6ff),
@@ -346,8 +346,8 @@ impl Theme {
             // Text
             text_primary: rgb(0xd4e4d1),
             text_secondary: rgb(0xa8c4a2),
-            text_muted: rgb(0x7a9a73),
-            text_on_accent: rgb(0xffffff),
+            text_muted: rgb(0x91ad8a),
+            text_on_accent: rgb(0x1a2418),
             icon_on_accent: rgb(0x1a2418),
             // Accent
             accent: rgb(0x6abf69),
@@ -356,7 +356,7 @@ impl Theme {
             // Semantic
             success: rgb(0x6abf69),
             warning: rgb(0xe0c062),
-            error: rgb(0xd96c6c),
+            error: rgb(0xf08585),
             info: rgb(0x6cb2d9),
             // Border
             border: rgb(0x3a4a35),
@@ -395,8 +395,8 @@ impl Theme {
             overlay_bg: rgba(0x00000088),
             // Text
             text_primary: rgb(0xffffff),
-            text_secondary: rgb(0x888888),
-            text_muted: rgb(0x555555),
+            text_secondary: rgb(0xbbbbbb),
+            text_muted: rgb(0x999999),
             text_on_accent: rgb(0x000000),
             icon_on_accent: rgb(0x000000),
             // Accent (white for high contrast on black background)

--- a/crates/gpui-toolkit/gpui-ui-kit/tests/components/icon_button_test.rs
+++ b/crates/gpui-toolkit/gpui-ui-kit/tests/components/icon_button_test.rs
@@ -35,12 +35,19 @@ fn test_icon_button_all_sizes() {
 
 #[test]
 fn test_icon_button_size_values() {
-    assert_eq!(IconButtonSize::Xs.size(), gpui::px(16.0));
-    assert_eq!(IconButtonSize::Sm.size(), gpui::px(20.0));
-    assert_eq!(IconButtonSize::Md.size(), gpui::px(24.0));
-    assert_eq!(IconButtonSize::Lg.size(), gpui::px(32.0));
-    assert_eq!(IconButtonSize::Xl.size(), gpui::px(48.0));
-    assert_eq!(IconButtonSize::Custom(40).size(), gpui::px(40.0));
+    // Sizes are in rems so the click target scales with window.set_rem_size
+    // (font zoom). Sm/Md/Lg/Xl all meet WCAG 2.5.8 24×24 at 1× zoom; Xs is
+    // intentionally below that floor for dense / chart-internal use.
+    // If you change the rem mapping, audit every IconButton call site in
+    // app-gpui — Sm and Md are visually identical at 1× zoom on purpose,
+    // so changes propagate to footer-transport, dialog-close, and other
+    // IconButton::Sm sites.
+    assert_eq!(IconButtonSize::Xs.size(), gpui::rems(1.0));
+    assert_eq!(IconButtonSize::Sm.size(), gpui::rems(1.5));
+    assert_eq!(IconButtonSize::Md.size(), gpui::rems(1.5));
+    assert_eq!(IconButtonSize::Lg.size(), gpui::rems(2.0));
+    assert_eq!(IconButtonSize::Xl.size(), gpui::rems(3.0));
+    assert_eq!(IconButtonSize::Custom(40).size(), gpui::rems(2.5));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two foundational `gpui-ui-kit` fixes that flow from the parallel UX audit:

1. **Theme palette WCAG AA fixes** (`A11y Phase A1`): contrast audit found that only Onyx passes AA across all standard role pairings. Critical: Midnight + Forest fail white-on-accent at **2.27** / **2.53** — every primary CTA / selected tab unreadable. `text_muted` fails normal-text contrast in 5 of 6 themes.
2. **`IconButton` size in rems + WCAG 24×24 floor** (`A11y Phase A2`): `IconButtonSize::size()` returned absolute `Pixels`, so click targets stayed fixed while everything around them scaled with font zoom. `Sm` was 20 px (below WCAG 2.5.8 minimum). Both fixed in one go.

## Theme contrast fixes (A1)

Per-pairing changes — preserves brand hue, only lightness / inversion changes:

| Theme | Field | Before | After | Ratio change |
|---|---|---|---|---|
| Midnight | `text_on_accent` | `#ffffff` | `#0d1117` | 2.53 → ~9.5 |
| Forest | `text_on_accent` | `#ffffff` | `#1a2418` | 2.27 → ~7.5 |
| Dark | `text_muted` | `#888888` | `#9c9c9c` | 4.05 → ~5.0 |
| Dark | `error` | `#ef4444` | `#f87171` | 3.81 → ~5.5 |
| Light | `text_muted` | `#888888` | `#666666` | 3.54 → ~5.7 |
| Light | `success/warning/error/info` | Tailwind 600 | Tailwind 700 | all ≥4.5 |
| Forest | `text_muted` | `#7a9a73` | `#91ad8a` | 4.05 → ~4.6 |
| Forest | `error` | `#d96c6c` | `#f08585` | 3.81 → ~5.0 |
| Midnight | `text_muted` | `#6e7681` | `#8b949e` | 3.31 → ~4.6 |
| BlackAndWhite | `text_muted` | `#555555` | `#999999` | 2.47 → ~5.2 |
| BlackAndWhite | `text_secondary` | `#888888` | `#bbbbbb` | (preserve hierarchy) |

**Out of scope for this PR**:
- Border contrast (1.21–1.48 across all dark themes). Borders are decorative today; bumping them is a 1.4.11 UI-component fix that needs per-component judgment.
- BlackAndWhite semantic colors (gray-coded error/warning/success). Encoding state purely as different grays violates 1.4.1 Use of Color regardless of contrast — needs shape/icon redundancy, not a palette tweak.

## IconButton fixes (A2)

`IconButtonSize::size()` now returns `Rems` instead of `Pixels`. New mapping:

```
Xs  → rems(1.0)    ≈ 16 px (intentionally below WCAG floor)
Sm  → rems(1.5)    ≈ 24 px  (was rems(1.25) ≈ 20 px)
Md  → rems(1.5)    ≈ 24 px  (default, unchanged)
Lg  → rems(2.0)    ≈ 32 px  (unchanged)
Xl  → rems(3.0)    ≈ 48 px  (unchanged)
Custom(n)          → rems(n / 16.0)
```

The 4 `IconButtonSize::Sm` sites in `app-gpui` — all in `home/footer.rs` (Previous, Seek-Back, Seek-Fwd, Next transport buttons) — automatically get the WCAG-compliant 24×24 click target without per-call-site edits. The `Md` Play/Pause button stays at 24 px; this collapses the Sm/Md visual distinction in the transport row, which fits the "all transport peers" semantic.

`Xs` deliberately stays below the WCAG floor for known non-target contexts (chart axis micro-icons, dense diagnostic readouts). The doc comment on the enum spells this out.

The pinning test `test_icon_button_size_values` updates to assert the new rem mapping with a comment warning that `Sm` and `Md` are intentionally identical at 1× zoom.

## What's NOT in this PR (deferred)

**Phase A3 — focus-visible styling on Button + IconButton.** GPUI's `.focus_visible(|s| s.border(...))` is the right primitive, but it requires a persistent `FocusHandle` per element which `RenderOnce` components can only get via a thread-local registry (the same pattern `input.rs` uses). That's a ~3-4 file architectural change (registry + Enter/Space activation + tests) with behavioral implications (every Button becomes Tab-reachable). Worth a separate PR with its own review.

## Verification

- [x] `cargo check -p gpui-ui-kit` — clean
- [x] `cargo check -p sotf-gpui` — clean (downstream `.w(size).h(size)` continues to work because `Rems → Length` is automatic)
- [x] `cargo test -p gpui-ui-kit` — **686 passed**, 0 failed (includes the updated `test_icon_button_size_values` pinning the new rem mapping)
- [ ] Visual QA: `cargo run --bin SotF --release` and cycle through all 6 themes. Especially Light theme (where the semantic-color shift toward 700-step is the most noticeable change), and Midnight/Forest primary CTAs (which become legible for the first time).

## Test plan

- [ ] Light theme: confirm error/warning/success badges still read as red/yellow/green at body text size (now darker but still color-distinguishable).
- [ ] Midnight + Forest: primary buttons + selected tabs should now show dark text on the colored accent — confirm legibility from typical reading distance.
- [ ] Footer transport row: Previous / Seek±30s / Next buttons should now be 24 px tall instead of 20 px, matching the Play/Pause button. The transport HStack alignment should remain visually balanced.
- [ ] All 6 themes: confirm `text_muted` is now readable for album-card metadata, chart axis labels, input placeholders.

## Roadmap

This is **2 of 7** UX audit dimensions started after the parallel agent sweep:

| # | Dimension | Status |
|---|---|---|
| 1 | Click targets | **A2 in this PR** (IconButton); 3 critical sites in plugins/EQ + matrix MSD remain |
| 2 | Color contrast | **A1 in this PR**; border + BlackAndWhite-semantic deferred |
| 3 | Empty-state consistency | not started |
| 4 | Focus / keyboard nav | **A3 deferred to follow-up** |
| 5 | Loading + error states | not started |
| 6 | i18n coverage | not started |
| 7 | ARIA tree | not started |

https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPZzppVzGF1zwzTQG4ZTVY)_