### PR TITLE
Remove unused workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,6 @@ gpui_macos = { version="0.1.0", git = "https://github.com/zed-industries/zed.git
 gpui_linux = { version="0.1.0", git = "https://github.com/zed-industries/zed.git", tag = "v1.9.0" }
 gpui_windows = { version="0.1.0", git = "https://github.com/zed-industries/zed.git", tag = "v1.9.0" }
 gpui_wgpu = { version="0.1.0", git = "https://github.com/zed-industries/zed.git", tag = "v1.9.0" }
-wgpu = { version="29.0.0", git = "https://github.com/zed-industries/wgpu.git", branch = "v29" }
 
 # System and low-level
 objc = "0.2"
@@ -343,8 +342,6 @@ proptest = "1.9"
 syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
 
 # Graphics and visualization
-plotly = "0.13"
-plotly_static = { version = "0.1", features = ["chromedriver", "webdriver_download"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 glam = "0.30"
 pollster = "0.4"
@@ -353,7 +350,6 @@ fontdue = "0.9"
 delaunator = "1.0"
 raw-window-handle = "0.6"
 pathfinder_geometry = "0.5"
-smallvec = { version = "1.6", features = ["union", "const_new"] }
 
 # GPU and macOS graphics
 oslog = "0.2"


### PR DESCRIPTION
Closes #210.

## Summary
- Remove unused root workspace declarations for `plotly`, `plotly_static`, `smallvec`, and `wgpu`.
- Preserve `gpui_wgpu` and all transitive WGPU/smallvec dependencies used by workspace crates.
- Leave `Cargo.lock` unchanged because none of the removed aliases participated in the resolved graph.

## Verification
- TokenSave and manifest search found no workspace consumers of the four declarations.
- `cargo metadata --locked --no-deps --format-version 1`: passed; no lockfile change
- `cargo check --workspace`: passed
- `cargo clippy --workspace`: passed
- `git diff --check`: passed
- `cargo test --workspace`: all reported suites passed except `ios_project_uses_sotfplayer_as_the_canonical_app_target` during the aggregate run; the exact test passed when rerun in isolation

## Residual risk
- The aggregate workspace gate remains non-green due to the existing load/order-sensitive iOS project-layout test. This manifest-only cleanup does not touch the iOS project or its tests.